### PR TITLE
Simplified Scripts for AT&T/DirecTV Osprey hardware

### DIFF
--- a/scripts/osprey/directv/bmitune.sh
+++ b/scripts/osprey/directv/bmitune.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+#bmitune.sh for osprey/directv
+
+#Debug on if uncommented
+set -x
+
+#Global
+channelID=\""$1\""
+specialID="$1"
+streamerIP="$2"
+streamerNoPort="${streamerIP%%:*}"
+adbTarget="adb -s $streamerIP"
+m3uName="${STREAMER_APP#*/*/}.m3u"
+
+
+#Trap end of script run
+finish() {
+  echo "bmitune.sh is exiting for $streamerIP with exit code $?"
+}
+
+trap finish EXIT
+
+#Set encoderURL based on the value of streamerIP
+matchEncoderURL() {
+
+  case "$streamerIP" in
+    "$TUNER1_IP")
+      encoderURL=$ENCODER1_URL
+      ;;
+    "$TUNER2_IP")
+      encoderURL=$ENCODER2_URL
+      ;;
+    "$TUNER3_IP")
+      encoderURL=$ENCODER3_URL
+      ;;
+    "$TUNER4_IP")
+      encoderURL=$ENCODER4_URL
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+}
+
+#Tuning is based on channel name values from $m3uName.
+tuneChannel() {
+  
+  $adbTarget shell input text $channelID; 
+}
+
+
+main() {
+  matchEncoderURL
+  tuneChannel
+}
+
+main

--- a/scripts/osprey/directv/prebmitune.sh
+++ b/scripts/osprey/directv/prebmitune.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#prebmitune.sh for osprey/directv
+
+#Debug on if uncommented
+set -x
+
+streamerIP="$1"
+streamerNoPort="${streamerIP%%:*}"
+adbTarget="adb -s $streamerIP"
+
+mkdir -p $streamerNoPort
+
+#Trap end of script run
+finish() {
+  echo "prebmitune.sh is exiting for $streamerIP with exit code $?"
+}
+
+trap finish EXIT
+
+adbConnect() {
+  adb connect $streamerIP
+
+  local -i adbMaxRetries=3
+  local -i adbCounter=0
+
+  while true; do
+    $adbTarget shell input keyevent KEYCODE_WAKEUP
+    local adbEventSuccess=$?
+
+    if [[ $adbEventSuccess -eq 0 ]]; then
+      break
+    fi
+
+    if (($adbCounter > $adbMaxRetries)); then
+      touch $streamerNoPort/adbCommunicationFail
+      echo "Communication with $streamerIP failed after $adbMaxRetries retries"
+      exit 2
+    fi
+    
+
+    ((adbCounter++))
+  done
+}
+
+adbWake() {
+
+    $adbTarget shell input keyevent KEYCODE_WAKEUP; sleep 2;
+    echo "Waking $streamerIP"
+    touch $streamerNoPort/adbAppRunning
+
+}
+
+main() {
+  adbConnect
+  adbWake
+}
+
+main

--- a/scripts/osprey/directv/stopbmitune.sh
+++ b/scripts/osprey/directv/stopbmitune.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#stopbmitune.sh for osprey/directv
+
+#Debug on if uncommented
+set -x
+
+streamerIP="$1"
+streamerNoPort="${streamerIP%%:*}"
+adbTarget="adb -s $streamerIP"
+
+#Device sleep
+adbSleep() {
+  sleep="input keyevent KEYCODE_SLEEP"
+
+  $adbTarget shell $sleep
+  echo "Sleep initiated for $streamerIP"
+  date +%s > $streamerNoPort/stream_stopped
+  echo "$streamerNoPort/stream_stopped written with epoch stop time"
+}
+
+main() {
+  adbSleep
+}
+
+main


### PR DESCRIPTION
Using FireTV tuning scripts as reference, all three scripts for Osprey have been pruned to match the special operation of the AT&T/DirecTV Osprey Hardware.  As this Android Streaming Box natively runs the DirecTV app as a launcher, there is no need to verify an app is open or closed.  These scripts simply wake or sleep the Osprey Box and send channel number inputs via ADB input to tune.  Scripts verified on models Osprey Models C71KW-200 and C71KW-400.