### PR TITLE
tuning for android PBS app, including multiple PBS affiliates

### DIFF
--- a/m3u/pbs-seatac.m3u
+++ b/m3u/pbs-seatac.m3u
@@ -1,0 +1,7 @@
+#EXTM3U
+
+#EXTINF:-1 channel-id="KCTS" channel-number="9" tvc-guide-stationid="19631",KCTS
+http://{{ .IPADDRESS }}/play/tuner/KCTS-Cascade-PBS_98011_1
+
+#EXTINF:-1 channel-id="KBTC" channel-number="28" tvc-guide-stationid="34635",KBTC
+http://{{ .IPADDRESS }}/play/tuner/KBTC-Public-Television_98011_2

--- a/m3u/pbs-worcester.m3u
+++ b/m3u/pbs-worcester.m3u
@@ -1,10 +1,10 @@
 #EXTM3U
 
-#EXTINF:-1 channel-id="WGBH-GBH" channel-number="2" tvc-guide-stationid="28055",WGBH
-http://{{ .IPADDRESS }}/play/tuner/WGBH_01601_1
+#EXTINF:-1 channel-id="WGBH" channel-number="2" tvc-guide-stationid="28055",WGBH
+http://{{ .IPADDRESS }}/play/tuner/WGBH-GBH_01601_1
 
-#EXTINF:-1 channel-id="WSBE-Rhode-Island-PBS" channel-number="36" tvc-guide-stationid="34635",WSBE
-http://{{ .IPADDRESS }}/play/tuner/WSBE_01601_2
+#EXTINF:-1 channel-id="WSBE" channel-number="36" tvc-guide-stationid="34635",WSBE
+http://{{ .IPADDRESS }}/play/tuner/WSBE-Rhode-Island-PBS_01601_2
 
-#EXTINF:-1 channel-id="WFCR-New-England-Public-Media" channel-number="57" tvc-guide-stationid="",WFCR
-http://{{ .IPADDRESS }}/play/tuner/WFCR_01601_3
+#EXTINF:-1 channel-id="WFCR" channel-number="57" tvc-guide-stationid="",WFCR
+http://{{ .IPADDRESS }}/play/tuner/WFCR-New-England-Public-Media_01601_3

--- a/m3u/pbs-worcester.m3u
+++ b/m3u/pbs-worcester.m3u
@@ -1,0 +1,10 @@
+#EXTM3U
+
+#EXTINF:-1 channel-id="WGBH-GBH" channel-number="2" tvc-guide-stationid="28055",WGBH
+http://{{ .IPADDRESS }}/play/tuner/WGBH_01601_1
+
+#EXTINF:-1 channel-id="WSBE-Rhode-Island-PBS" channel-number="36" tvc-guide-stationid="34635",WSBE
+http://{{ .IPADDRESS }}/play/tuner/WSBE_01601_2
+
+#EXTINF:-1 channel-id="WFCR-New-England-Public-Media" channel-number="57" tvc-guide-stationid="",WFCR
+http://{{ .IPADDRESS }}/play/tuner/WFCR_01601_3

--- a/scripts/chromecast/pbs/README.txt
+++ b/scripts/chromecast/pbs/README.txt
@@ -1,0 +1,139 @@
+Tunes live TV in the PBS app.
+
+* PBS STREAMING INFRASTRUCTURE
+
+Most PBS affiliates use the streaming platform operated by the
+national PBS umbrella organization, and that's what the PBS app
+is for. I think there are a few PBS affiliates that use some
+different infrastructure for streaming, and you won't be able
+to use the PBS app and these scripts for those affiliates.
+
+The scripts here are aimed at navigating to a PBS affiliate's
+live stream. They don't know anything about on-demand programming,
+even though it is available in the same PBS app.
+
+* SCRIPTS STRUCTURE AND CONFIGURATION
+
+Our caller, ah4c, expects there to exist 3 scripts: "prebmitune.sh",
+"bmitune.sh", and "stopbmitune.sh". For this set of scripts, there are
+several common definitions, functions, etc.  Each of the expected
+scripts is a trivial 3-liner that sources "common.sh" and then calls
+the applicable function defined within "common.sh". The intent of that
+arrangement is to achive more consistent naming, simpler editing, and
+so on.
+
+At the top of "common.sh" is a collection of variables whose names
+start with "CONFIG_". As you might guess, those are things that
+conditionally control aspects of the scripts behaviors. If you are
+happy with the default values defined in "common.sh", then that's all
+you need to know. If you want to change any of them, you can, of
+course, just modify "common.sh".  A better way is to create a file in
+this same directory called "config-local.sh" and provide modified
+values for just the items of interest. Copy/paste/modify is the most
+reliable way of doing that. The advantage of using "config-local.sh"
+is that your changes would not be overwritten by any updates to this
+set of scripts. If you don't want to modify any config values, it is
+not necessary to create "config-local.sh" at all.
+
+* TUNING AND STATION SELECTION
+
+The channel tuning info (the final part of the URLs in the m3u) can be
+one of two forms:
+
+"Waaa"
+  or
+"Waaa_12345_2".
+
+In both cases, the tag "Waaa" (or whatever) is ignored.  It's just
+documentation for you, our dear user. Station call sign or marketing
+names are good choices. For the second form, the separator character
+is underscore, so don't include any underscores in the tag. For URL
+reasons, don't include any slashes or spaces or other URL unsafe
+characters in any part of the channel tuning info.
+
+For the first form, live TV is selected with whatever local PBS
+channel you have last configured in the app. This is most useful for
+the majority of places which are only served by a single PBS affiliate
+(or if you only ever watch a single affiliate).
+
+The second form has a ZIP code used to populate the app's search box
+for stations. The last number is a one-based position in the results
+list. I'm hoping the results always come back in the same order, but I
+have no way to verify that. This is most useful for places served by 2
+or more PBS affiliates. There are many places with 2 and a few places
+with 3. I don't know if there are any places with more than 3.
+
+For example, in the Seattle and Tacoma, Washington, area, there are 2
+PBS affiliates. If you search for a Seattle area ZIP code, you get 2
+results back. So far, I've always seen them come back as KCTS (the
+Seattle affiliate) first and KBTC (the Tacoma affiliate) second. You
+select which one you want with either "_1" or "_2". You can see this
+in the sample M3U pbs-seatac.m3u. There's another example M3U,
+pbs-worcester.m3u, for a ZIP code in Worcester, Massachusetts. That
+ZIP code search offers a choice of 3 PBS affiliates.
+
+The tuning script remembers the last station it tuned, so it only goes
+through the station search dialog if it needs to change to a different
+PBS affiliate (or if a lot of time has passed).
+
+NOTE: Although the search for affiliates is based on the ZIP code
+entered in the search box, the PBS streaming platform does geographic
+restrictions based on the source IP address it sees. That's why you
+can't watch out-of-area PBS programming. The PBS app will let you
+search for any ZIP code and will display the results. Selecting an
+out-of-area PBS affiliate in the search results will give an error
+message. The code in these scripts doesn't have a way of knowing that
+and assumes the station selection went correctly. There's also a small
+chance that your ISP's location will be different from your location
+for the purposes of PBS restrctions. If you can select it manually in
+the PBS app, the scripts can select it.
+
+* DELAYS
+
+The scripts work mostly by doing what's called "remote emulation".
+That is, they use adb commands to simulate button presses on a remote
+control. When a human operates the remote, it's obvious when they can
+press more buttons. The scripts mostly don't know when a reaction has
+happened on the screen, so they resort to a bunch of fixed delays to
+wait until the right time for the next thing. Those delays are a bit
+fiddly and depend on your specific equipment, what your equipment is
+doing at the moment, and, in some cases, the response time to network
+requests over the internet. Phase of the moon might be in there
+somewhere.
+
+Delays are expressed in seconds and need not be limited to whole
+numbers. Decimal fraction amounts are acceptable, e.g., "1.345".
+
+Instead of calling sleep directly, the scripts use the "settle"
+function (defined in "common.sh") which scales how much they
+sleep. When called, that function alters the requested sleep duration
+according to CONFIG_DELAY_SCALING and CONFIG_DELAY_OFFSET.  If the
+scaling is 1 and the offset is 0 (the defaults), you get exactly the
+sleep durations coded into the scripts. If you need proportionally
+longer delays, increase the scaling. If you want proportionally
+shorter delays, decrease the scaling.  If you want to add (or
+subtract) a fixed amount to each delay, set the offset to that amount.
+If you configure the scaling and offset values to 0, sleep becomes a
+no-op (which probably will not be a good choice).
+
+There are CONFIG_ items for each individual delay. Instead of scaling
+or offsetting them across the board, you can adjust them individually.
+
+The advantage of long delays is that you can be sure your device has
+finished reacting to inputs before the script moves on to the next
+thing.
+
+The disadvantage of having overly long delays is that you risk losing
+the beginning of real programming. For example, if you are recording a
+30 minute program and you have 1 minute worth of delays, then the
+first minute of the recording will be showing this tuning noise
+instead of the first minute of the real program. For PBS shows, that
+usually doesn't matter since they tend to thank sponsors at the
+beginning and sometimes show a preview of the show. However, it's best
+to not rely on that and have the delays as short as you can and still
+have them tune reliably.  Timing is trickiest if you have multiple PBS
+affiliates and need to change your local station before recording.
+
+In my environment, with the default delays, it takes about 30 seconds
+to tune when a station change is required. It takes about 12 seconds
+when a channel change is not required.

--- a/scripts/chromecast/pbs/README.txt
+++ b/scripts/chromecast/pbs/README.txt
@@ -136,4 +136,7 @@ affiliates and need to change your local station before recording.
 
 In my environment, with the default delays, it takes about 30 seconds
 to tune when a station change is required. It takes about 12 seconds
-when a channel change is not required.
+when a channel change is not required. Tested on Google Chromecast HD,
+Tivo Stream 4k, and Onn 2k Stick. I also tested against a fairly old
+Amazon Fire TV stick, though I had to scale the delays a bit for that
+to work.

--- a/scripts/chromecast/pbs/bmitune.sh
+++ b/scripts/chromecast/pbs/bmitune.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. `dirname $0`/common.sh
+bmitune "$@"

--- a/scripts/chromecast/pbs/common.sh
+++ b/scripts/chromecast/pbs/common.sh
@@ -114,9 +114,9 @@ waitForWakeUp() {
 
     while true
     do
-	screenOn=` $ADB_ shell "input keyevent KEYCODE_WAKEUP ; dumpsys deviceidle get screen" `
-	echo "screen on? ${screenOn}"
-	if [ ${screenOn} = "true" ]; then
+	# Fire TV returns dumpsys output with CRLF line endings; what an annoyance
+	displayState=` $ADB_ shell "input keyevent KEYCODE_WAKEUP ; dumpsys display" | grep -e 'mGlobalDisplayState=' -e 'Display State=' -m 1 | cut -d= -f2 | tr -d '\r\n' `
+	if [ ${displayState} = "ON" ]; then
 	    break
 	fi
 
@@ -222,7 +222,8 @@ matchEncoderURL() {
 }
 
 getCurrentFocus() {
-    appFocus=$($ADB_ shell dumpsys window | grep -E 'mCurrentFocus' | sed -e 's/.* //g' -e 's/}$//' )
+    # Fire TV returns dumpsys output with CRLF line endings.
+    appFocus=$($ADB_ shell dumpsys window | grep -E 'mCurrentFocus' | sed -e 's/.* //g' -e 's/}//' -e 's/\r//' )
     echo "${appFocus}"
 }
 

--- a/scripts/chromecast/pbs/common.sh
+++ b/scripts/chromecast/pbs/common.sh
@@ -1,0 +1,374 @@
+# Shell script debugging on if uncommented
+set -x
+
+#Trap end of script run
+finish() {
+    echo "$0 is exiting for ${STREAMER_IP} with exit code $?"
+}
+trap finish EXIT
+
+## When done with a stream, should we do a force-stop on the streaming app?
+##
+CONFIG_STOP_DOES_APP_FORCE_STOP="true"
+
+## When done with a stream, should we send a HOME button press to the device?
+##
+CONFIG_STOP_DOES_DEVICE_HOME="true"
+
+## When done with a video stream, should the Android device be put to
+## sleep? I don't know if this saves any significant resources, since
+## there is no screen, but it might ease the burden on the HDMI
+## encoder device; mine switches to a static image. Set this to false
+## if it seems like Channels has problems when the device needs waking
+## up.
+##
+CONFIG_STOP_DOES_DEVICE_SLEEP="false"
+
+## If you opt to put the device to sleep, you may find it useful to
+## wait for the screen to come back on in the prebmitune.sh
+## step. Regardless, we always check for screen on in the bmitune.sh
+## step.
+##
+CONFIG_PRETUNE_WAIT_FOR_SCREEN="true"
+
+## The PBS app should be taken to the main panel, even if it's already
+## running. If for some reason that isn't working correctly, you can
+## force-stop it first. The idea is for the scripts to be in a known
+## place when navigating.
+##
+CONFIG_FORCE_STOP_BEFORE_APP_START="true"
+
+## Normall only go through station search when actually needed. This is a
+## sort of failsafe that forces a station search after a period of time.
+##
+CONFIG_FORCE_STATION_CHANGE_AFTER="14400"
+
+## See the "DELAYS" section in README.txt for some considerations.
+CONFIG_DELAY_SCALING="1"
+CONFIG_DELAY_OFFSET="0"
+
+CONFIG_SETTLE_ITERATING_FOR_SCREEN_ON="0.5"
+CONFIG_SETTLE_ITERATING_FOR_BMITUNE_DONE="2"
+CONFIG_SETTLE_ITERATING_SEARCH_RESULTS="0.5"
+CONFIG_SETTLE_ITERATING_APP_LAUNCH_CHECK="1"
+
+CONFIG_SETTLE_AFTER_SCREEN_ON="0.6"
+CONFIG_SETTLE_AFTER_LAUNCH_APP="3"
+CONFIG_SETTLE_AFTER_KEY_INPUT="2"
+CONFIG_SETTLE_MAIN_PANEL_TO_LIVE_PANEL="3"
+CONFIG_SETTLE_BEFORE_WATCH_NOW="0.5"
+CONFIG_SETTLE_AWAIT_SEARCH_RESULTS="4"
+CONFIG_SETTLE_AFTER_SELECT_STATION="5"
+CONFIG_SETTLE_AFTER_FORCE_STOP="0.4"
+
+###################################################################
+# end of user configuration options ... don't change things below #
+###################################################################
+APP_PACKAGE="com.pbs.video"
+# using this bypasses the splash screen
+APP_ACTIVITY=".tv.ui.home.TvMainActivity"
+
+## "config-local.sh" is optional and allows for overriding config values without directly editing the scripts.
+LF=`dirname $0`/config-local.sh
+if [ -f "${LF}" ]
+then
+    . "${LF}"
+fi
+
+# Functions with prefix "pbs" are specific to the PBS app. Other functions are more or less generic.
+
+# define a few adb command fragments ("R_" is mnemonic for "remote control" even though some are not buttons on the remote)
+R_ENTER="shell input keyevent KEYCODE_ENTER"
+R_RIGHT="shell input keyevent KEYCODE_DPAD_RIGHT"
+R_CENTER="shell input keyevent KEYCODE_DPAD_CENTER"
+R_DOWN="shell input keyevent KEYCODE_DPAD_DOWN"
+R_SLEEP="shell input keyevent KEYCODE_SLEEP"
+R_HOME="shell input keyevent KEYCODE_HOME"
+R_TEXT="shell input text"
+R_FORCE_STOP="shell am force-stop"
+R_LAUNCH_APP="shell am start -W -n"
+
+init() {
+    STREAMER_WITH_PORT="$1"
+    STREAMER_NO_PORT="${STREAMER_WITH_PORT%%:*}"
+    ADB_="adb -s ${STREAMER_WITH_PORT}"
+}
+
+## At various points, we have to wait for the physical device to do something. We call that
+## "settling time". Value in seconds, not limited to integers. See README.txt.
+settle() {
+    # we have to use bc because the terms are floating point and bash can only do integers
+    # avoid bc's truncating division
+    calculation="(${1} * ${CONFIG_DELAY_SCALING}) + (${CONFIG_DELAY_OFFSET})"
+    delay=`echo "${calculation}" | bc -q`
+    echo "settle ${calculation}"
+    if [ "${delay:0:1}" != "-" ]
+    then
+	sleep "${delay}"
+    fi
+}
+
+waitForWakeUp() {
+    local -i maxRetries=15
+    local -i retryCounter=0
+
+    while true
+    do
+	screenOn=` $ADB_ shell "input keyevent KEYCODE_WAKEUP ; dumpsys deviceidle get screen" `
+	echo "screen on? ${screenOn}"
+	if [ ${screenOn} = "true" ]; then
+	    break
+	fi
+
+	if ((${retryCounter} > ${maxRetries})); then
+	    touch $STREAMER_NO_PORT/adbCommunicationFail
+	    echo "Communication with ${STREAMER_WITH_PORT} failed after ${maxRetries} retries"
+	    exit 1
+	fi
+
+	# we need to beat a relatively short Channels connection timeout (8-10 seconds), so we use only short sleeps per iteration
+	settle "${CONFIG_SETTLE_ITERATING_FOR_SCREEN_ON}"
+	((retryCounter++))
+    done
+    settle ${CONFIG_SETTLE_AFTER_SCREEN_ON}
+}
+
+
+# Check if bmitune.sh is done running. The stopbmitune.sh script might be called while bmitune.sh is still going.
+waitForBmituneDone() {
+    bmitunePID=$(<"$STREAMER_NO_PORT/bmitune_pid")
+
+    while ps -p ${bmitunePID} > /dev/null 2>&1 ; do
+	echo "Waiting for bmitune.sh to complete..."
+	settle "${CONFIG_SETTLE_ITERATING_FOR_BMITUNE_DONE}"
+    done
+}
+
+waitForAppLaunch() {
+    local -i maxRetries=15
+    local -i retryCounter=0
+
+    while true
+    do
+	focus=`getCurrentFocus`
+	if ((${retryCounter} > ${maxRetries})); then
+	    echo "App ${APP_PACKAGE} doesn't seem to be launching. Current focus is ${focus}"
+	    exit 3
+	fi
+	if [ "${focus}" = "${APP_PACKAGE}/${APP_PACKAGE}${APP_ACTIVITY}" ]
+	then
+	    return 0
+	fi
+	settle "${CONFIG_SETTLE_ITERATING_APP_LAUNCH_CHECK}"
+	((retryCounter++))
+    done
+}
+
+# either way, this should leave us at the app startup main page
+launchTheApp() {
+    if [ "${CONFIG_FORCE_STOP_BEFORE_APP_START}" = "true" ]
+    then
+	echo "FORCE STOP ${APP_PACKAGE}"
+        $ADB_ ${R_FORCE_STOP} "${APP_PACKAGE}"
+	settle "${CONFIG_SETTLE_AFTER_FORCE_STOP}"
+    fi
+
+    echo "STARTING ${APP_PACKAGE}/${APP_ACTIVITY}"
+    $ADB_ ${R_LAUNCH_APP} "${APP_PACKAGE}/${APP_ACTIVITY}"
+    # even though we did "-W" to wait, we might still need to wait a bit in case there is a splash screen or other lag
+    waitForAppLaunch
+    settle "${CONFIG_SETTLE_AFTER_LAUNCH_APP}"
+    touch $STREAMER_NO_PORT/adbAppRunning
+}
+
+stopTheApp() {
+    if [ "${CONFIG_STOP_DOES_APP_FORCE_STOP}" = "true" ]
+    then
+	$ADB_ ${R_FORCE_STOP} ${APP_PACKAGE}
+    fi
+    if [ "${CONFIG_STOP_DOES_DEVICE_HOME}" = "true" ]
+    then
+	$ADB_ ${R_HOME}
+    fi
+    echo "Streaming stopped for ${STREAMER_WITH_PORT}"
+}
+
+#Device sleep
+putTheDeviceToSleep() {
+    $ADB_ ${R_SLEEP}
+    echo "Device sleep initiated for ${STREAMER_WITH_PORT}"
+}
+
+updateReferenceFiles() {
+  # Handle cases where stream_stopped or last_channel don't exist
+  mkdir -p $STREAMER_NO_PORT
+  [[ -f "$STREAMER_NO_PORT/stream_stopped" ]] || echo 0 > "$STREAMER_NO_PORT/stream_stopped"
+  [[ -f "$STREAMER_NO_PORT/last_channel" ]] || echo 0 > "$STREAMER_NO_PORT/last_channel"
+
+  # Write PID for this script to bmitune_pid for use in stopbmitune.sh
+  echo $$ > "$STREAMER_NO_PORT/bmitune_pid"
+  echo "Current PID for this script is $$"
+}
+
+# Set encoderURL based on the value of streamer IP. This is for multi-encoder environments.
+matchEncoderURL() {
+  case "${STREAMER_WITH_PORT}" in
+    "$TUNER1_IP") encoderURL=$ENCODER1_URL ;;
+    "$TUNER2_IP") encoderURL=$ENCODER2_URL ;;
+    "$TUNER3_IP") encoderURL=$ENCODER3_URL ;;
+    "$TUNER4_IP") encoderURL=$ENCODER4_URL ;;
+    *) exit 1 ;;
+  esac
+}
+
+getCurrentFocus() {
+    appFocus=$($ADB_ shell dumpsys window | grep -E 'mCurrentFocus' | sed -e 's/.* //g' -e 's/}$//' )
+    echo "${appFocus}"
+}
+
+#Special channels to kill app or reboot device
+specialChannels() {
+
+    if [ $REQUESTED_THING = "exit" ]; then
+      echo "Exit $APP_PACKAGE requested on ${STREAMER_WITH_PORT}"
+      rm $STREAMER_NO_PORT/last_channel $STREAMER_NO_PORT/adbAppRunning
+      $ADB_ shell am force-stop $APP_PACKAGE
+      exit 0
+    elif [ $REQUESTED_THING = "reboot" ]; then
+      echo "Reboot ${STREAMER_WITH_PORT} requested"
+      rm $STREAMER_NO_PORT/last_channel $STREAMER_NO_PORT/adbAppRunning
+      $ADB_ reboot
+      exit 0
+    elif [[ -f $STREAMER_NO_PORT/adbCommunicationFail ]]; then
+      rm $STREAMER_NO_PORT/adbCommunicationFail
+      exit 1
+    else
+      echo "Not a special channel (exit nor reboot)"
+      appFocus=`getCurrentFocus`
+      echo "Current app in focus is $appFocus" 
+    fi
+}
+
+pbsFromLivePanelToChangeStationSearchPanel() {
+    echo "navigate LIVE PANEL to SEARCH PANEL"
+    echo "move RIGHT to 'change station' button"
+    $ADB_ $R_RIGHT
+    settle "${CONFIG_SETTLE_AFTER_KEY_INPUT}"
+    echo "press 'change station' button"
+    $ADB_ $R_CENTER
+    settle "${CONFIG_SETTLE_AFTER_KEY_INPUT}"
+}
+
+pbsSearchForZipcodeViaSearchBox() {
+    echo "search for term ${ZIPCODE}"
+    echo "Move RIGHT to text search box"
+    $ADB_ $R_RIGHT
+    settle "${CONFIG_SETTLE_AFTER_KEY_INPUT}"
+    echo "Send ZIPCODE ${ZIPCODE} to text search box"
+    $ADB_ ${R_TEXT} "${ZIPCODE}"
+    # need "enter" to execute the search (so we don't have to navigate)
+    $ADB_ $R_ENTER
+    settle "${CONFIG_SETTLE_AWAIT_SEARCH_RESULTS}"  # allow time for search results to come back
+}
+
+pbsNavigateSearchResults() {
+    echo "navigate SEARCH RESULTS to POSITION ${POSITION}"
+    for ((resultDex=1;resultDex<=POSITION;resultDex++)); do
+	echo "Key DOWN to position ${resultDex}"
+	$ADB_ $R_DOWN
+	settle "${CONFIG_SETTLE_ITERATING_SEARCH_RESULTS}"
+    done
+    echo "SELECT station"
+    $ADB_ $R_CENTER
+    settle "${CONFIG_SETTLE_AFTER_SELECT_STATION}"
+}
+
+pbsMaybeChangeStation() {
+    local lastChannel
+    local lastAwake
+    local timeNow
+    local timeElapsed
+    local maxTime="${CONFIG_FORCE_STATION_CHANGE_AFTER}"
+
+    lastChannel=$(<"$STREAMER_NO_PORT/last_channel")
+    lastAwake=$(<"$STREAMER_NO_PORT/stream_stopped")
+    timeNow=$(date +%s)
+    timeElapsed=$(($timeNow - $lastAwake))
+
+    if [ ${lastChannel} = ${REQUESTED_THING} ] && (( $timeElapsed < $maxTime )); then
+	echo "Last channel selected on this tuner (${lastChannel}), no channel change required"
+    else
+	if [ -f $STREAMER_NO_PORT/adbAppRunning ] && (( $timeElapsed < $maxTime )); then
+	    rm $STREAMER_NO_PORT/adbAppRunning
+	fi
+	echo $REQUESTED_THING > "$STREAMER_NO_PORT/last_channel"
+	pbsFromLivePanelToChangeStationSearchPanel
+	pbsSearchForZipcodeViaSearchBox
+	pbsNavigateSearchResults
+	# brought us back to the app home screen
+	pbsFromMainPanelToLivePanel
+    fi
+}
+
+pbsFromMainPanelToLivePanel() {
+    # select live TV
+    echo "navigate MAIN PANEL to LIVE PANEL"
+    $ADB_ $R_CENTER
+    settle "${CONFIG_SETTLE_MAIN_PANEL_TO_LIVE_PANEL}"
+}
+
+pbsFromLivePanelToPlaying() {
+    echo "navigate LIVE PANEL to PLAYING"
+    $ADB_ $R_CENTER
+    # no settle time needed
+}
+
+stopbmitune() {
+    init "$1"
+    waitForBmituneDone
+    stopTheApp
+    if [ "${CONFIG_STOP_DOES_DEVICE_SLEEP}" = "true" ]
+    then
+	putTheDeviceToSleep
+    fi
+    date +%s > $STREAMER_NO_PORT/stream_stopped
+    echo "$STREAMER_NO_PORT/stream_stopped written"
+}
+
+prebmitune() {
+    init "$1"
+    mkdir -p $STREAMER_NO_PORT
+    adb connect ${STREAMER_WITH_PORT}
+    # fire and forget the wakeup call to make sure the screen comes back on soon if it was off
+    $ADB_ shell input keyevent KEYCODE_WAKEUP
+    WAKEUP_EXIT_CODE="$?"
+    if [ "${CONFIG_PRETUNE_WAIT_FOR_SCREEN}" = "true" ]
+    then
+	waitForWakeUp
+    else
+	exit ${WAKEUP_EXIT_CODE}
+    fi
+}
+
+bmitune() {
+    init "$2"
+    IFS=_ read TAG ZIPCODE POSITION <<<${1}
+    if [ -z ${POSITION} ]; then POSITION="1"; fi
+    REQUESTED_THING="$1"
+    echo REQUESTED_THING is ${REQUESTED_THING}
+
+    launchTheApp
+    updateReferenceFiles
+    matchEncoderURL
+    specialChannels
+    waitForWakeUp
+    pbsFromMainPanelToLivePanel
+    # Tuning either does nothing but click the button, or it goes through the station selection dialog first
+    # launchTheApp leaves us at the "live TV" panel
+    if [ ! -z "${ZIPCODE}" ]
+    then
+        pbsMaybeChangeStation
+    fi
+    settle "${CONFIG_SETTLE_BEFORE_WATCH_NOW}"
+    pbsFromLivePanelToPlaying
+}

--- a/scripts/chromecast/pbs/prebmitune.sh
+++ b/scripts/chromecast/pbs/prebmitune.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. `dirname $0`/common.sh
+prebmitune "$@"

--- a/scripts/chromecast/pbs/stopbmitune.sh
+++ b/scripts/chromecast/pbs/stopbmitune.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. `dirname $0`/common.sh
+stopbmitune "$@"


### PR DESCRIPTION
See the included README.txt for various usage details. Uses remote emulation to access the live stream of the PBS app, including switching among multiple local PBS affiliates. Although filed under "chromecast", it also works on Fire TV devices.
