### PR TITLE
ah4c controlling kodi running on linux

### DIFF
--- a/scripts/chromecast/kodi_faves/README.txt
+++ b/scripts/chromecast/kodi_faves/README.txt
@@ -26,9 +26,11 @@ PREPARATION
   with no further input or interaction. Pop-ups or other confirmation things
   are OK if they automatically go away within a short amount of time.
 
-* From the "Favourites" window, select "Options" and use a ViewType of "WideList".
-  That's important because we have to move around in the list as if we were
-  using arrow keys, and the scripts only move down or up, not left or right.
+* If you plan to use "favourites navigation" to tune channels (which
+  is not the default option), then from the "Favourites" window,
+  select "Options" and use a ViewType of "WideList". That's important
+  because we have to move around in the list as if we were using arrow
+  keys, and the scripts only move down or up, not left or right.
 
 * Enable the kodi JSONRPC API via HTTP.
     - Settings > Services > Control
@@ -44,7 +46,7 @@ PREPARATION
   just above. See the configuration stuff below.
 
 * If you are running kodi on Android, you must configure adb access
-  from the ah4c server machine. If you are running koid on Linux, you
+  from the ah4c server machine. If you are running kodi on Linux, you
   must configure ssh access from the ah4c server machine to the box
   running kodi. Actually, if you don't attempt to do device
   sleep/wakeup, force stop, or reboot with the Linux flavor, you
@@ -80,17 +82,17 @@ is in case there is someday some other kind of kodi tuner that might
 share the script code. As a special favor (:-)) to Americans, you can
 use "favorites" (without the "u") as an acceptable alias.
 
-The last part is a URL-encoded string that must match an item in your
-favourites list. (Although you have to URL-encode it in your m3u, it's
-already been URL-decoded by the time it gets to these scripts.)
-Here."match" means it's either a complete or substring match done case
-insensitively. For example, "Foo%20Bar" would match a favorite channel
-with the label "My foo barlicious Channel". In the case of multiple
-matches in your favourites list, you don't really have much control
-over which one will be selected, so be as specific as possible. In the
-unlikely event that you have actual ambiguities in your favourites
-list, use the kodi favourites context menu to rename some of them to
-ensure uniqueness.
+The last part, the "tuning hint", is a URL-encoded string that must
+match an item in your favourites list. (Although you have to
+URL-encode it in your m3u, it's already been URL-decoded by the time
+it gets to these scripts.)  Here."match" means it's either a complete
+or substring match done case insensitively. For example, "Foo%20Bar"
+would match a favorite channel with the label "My foo barlicious
+Channel". In the case of multiple matches in your favourites list, you
+don't really have much control over which one will be selected, so be
+as specific as possible. In the unlikely event that you have actual
+ambiguities in your favourites list, use the kodi favourites context
+menu to rename some of them to ensure uniqueness.
 
 How do you know what the label is for a favourites item? It's not
 necessarily the same as whatever text appears in the logo or
@@ -103,7 +105,9 @@ cancel out of that after you have made a note of it.
 
 Don't use literal underscores other than to separate the 3 pieces as
 illustrated. And, except as just described, don't use any characters
-that may cause trouble in a URL.
+that may cause trouble in a URL. Even with URL-encoding, avoid
+anything special to Linux shells (single or double quotes, dollar
+signs, vertical bars, etc) in the tuning hint portion.
 
 * SCRIPTS STRUCTURE AND CONFIGURATION
 
@@ -206,7 +210,8 @@ After I got the kodi stuff working reasonably well on my Android TV
 dongles, I decided to see what my collection of ancient Raspberry Pi
 boards could do for me. After some experimenting, I settled on using
 LibreELEC, which is available in the standard Raspberry Pi imager
-tool.
+tool. I run that on a Raspberry Pi 3 with 1 GB RAM, booted from a 16
+GB thumb drive.
 
 Pro tip: If you are having problems with getting kodi to remember that
 you always want subtitles, you are not alone. This thread may help you

--- a/scripts/chromecast/kodi_faves/README.txt
+++ b/scripts/chromecast/kodi_faves/README.txt
@@ -35,6 +35,13 @@ PREPARATION
     - Enable SSL if desired (see kodi docs)
 * In the ah4c environment, you must configure the kodi password that you created
   just above. See the configuration stuff below.
+* If you are running kodi on Android, you must configure adb access
+  from the ah4c server machine. If you are running koid on Linux, you
+  must configure ssh access from the ah4c server machine to the box
+  running koid. (If you don't know about SSH keys, this article can help
+  you work through it: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-2)
+  Your are creating an SSH key for the Linux account that runs kodi. For LibreELEC,
+  that account is root. The SSH key is NOT for the JSONRPC account.
 
 NOTE: kodi's spelling is "favourites", not "favorites". That's the
 spelling you should use except as noted specifically below. Also, the
@@ -88,11 +95,20 @@ that may cause trouble in a URL.
 
 Our caller, ah4c, expects there to exist 3 scripts: "prebmitune.sh",
 "bmitune.sh", and "stopbmitune.sh". For this set of scripts, there are
-several common definitions, functions, etc.  Each of the expected
-scripts is a trivial 3-liner that sources "common.sh" and then calls
-the applicable function defined within "common.sh". The intent of that
-arrangement is to achive more consistent naming, simpler editing, and
-so on. All of the scripts redirect stdout to be on top of stderr.
+several common definitions, functions, etc. Each of the expected
+scripts is a trivial 4-liner that sets the FLAVOR, sources "common.sh"
+and then calls the applicable function defined within "common.sh". The
+intent of that arrangement is to achieve more consistent naming,
+simpler editing, and so on. All of the scripts redirect stdout to be
+on top of stderr.
+
+There is a 95%-plus overlap between the kodi scripts running on
+Android TV and kodi running on Linux. The top-level scripts
+set ane environment variable "FLAVOR" to indicate which flavor is
+being used, ("android" or "linux") and "common.sh" has conditional
+logic in the applicable places. There is only one copy of
+"common.sh". It's located under scripts/chromecast/kodi_faves/ because
+that's where it first appeared.
 
 At the top of "common.sh" is a collection of variables whose names
 start with "CONFIG_". As you might guess, those are things that
@@ -100,12 +116,16 @@ conditionally control aspects of the script behaviors. If you are
 happy with the default values defined in "common.sh", then that's all
 you need to know. If you want to change any of them, you can, of
 course, just modify "common.sh".  A better way is to create a file in
-this same directory called "config-local.sh" and provide modified
-values for just the items of interest. Copy/paste/modify is the most
-reliable way of doing that. The advantage of using "config-local.sh"
-is that your changes would not be overwritten by any updates to this
-set of scripts. One way or the other, you will have to at least
-configure the password for JSONRPC API access.
+the same directory (as common.sh) called "config-local.sh" and provide
+modified values for just the items of interest. Copy/paste/modify is
+the most reliable way of doing that. The advantage of using
+"config-local.sh" is that your changes would not be overwritten by any
+updates to this set of scripts. One way or the other, you will have to
+at least configure the password for JSONRPC API access. If you are
+running kodi on Linux, you will have to configure the ssh key.
+
+You can use the FLAVOR variable to put conditional logic into your
+"config-local.sh" file. The possible values are "android" and "linux".
 
 The scripts use a tool called "jq" for parsing JSON responses. jq
 is not present in the ah4c docker image, so the scripts detect that
@@ -157,16 +177,22 @@ as short as you can and still have them tune reliably.
 
 I got involved in this whole ah4c business because of a single local
 PBS station that I can't pick up with my antenna. I started out by
-using the PBS app with remote control emulation. That works, modulo
-the occasional loss-of-marbles, but it's fiddly at best. I also
-experimented with a different technique called VLC-bridge-PBS. That
-works really, really well, but I didn't find a way to enable closed
-captions. Sources for VLC-bridge-PBS don't seem to be available. In
-poking around, I saw that it's using a kodi plugin to handle
-DRM. That's what got me heading down the path of using kodi itself to
-"tune" the PBS station. kodi's rich API makes moving around the GUI
-pretty straightforward for most things, and that eliminates a lot of
-fiddliness.
+using the PBS app with remote control emulation an an Android TV
+dongle. That works, modulo the occasional loss-of-marbles, but it's
+fiddly at best. I also experimented with a different technique called
+VLC-bridge-PBS. That works really, really well, but I didn't find a
+way to enable closed captions. Sources for VLC-bridge-PBS don't seem
+to be available. In poking around, I saw that it's using a kodi plugin
+to handle DRM. That's what got me heading down the path of using kodi
+itself to "tune" the PBS station. kodi's rich API makes moving around
+the GUI pretty straightforward for most things, and that eliminates a
+lot of fiddliness.
+
+After I got the kodi stuff working reasonably well on my Android TV
+dongles, I decided to see what my collection of ancient Raspberry Pi
+boards could do for me. After some experimenting, I settled on using
+LibreELEC, which is available in the standard Raspberry Pi imager
+tool.
 
 Pro tip: If you are having problems with getting kodi to remember that
 you always want subtitles, you are not alone. This thread may help you

--- a/scripts/chromecast/kodi_faves/README.txt
+++ b/scripts/chromecast/kodi_faves/README.txt
@@ -13,17 +13,23 @@ quirky adb remote control emulation with finicky delays.
 PREPARATION
 
 * Obviously, install kodi.
+
 * Install whatever kodi add-ons you want to deal with live streams.
+
 * For any stream you want to treat as a "channel", add it to kodi "Favourites"
   (methods for that might vary with different kodi add-ons, but typically
   it will be some kind of context menu with "add to favourites" or similar).
+
 * Test manually to see that you can actually play all the desired stuff in kodi.
+
 * Also check that anything you select from the "Favourites" screen starts playing
   with no further input or interaction. Pop-ups or other confirmation things
   are OK if they automatically go away within a short amount of time.
+
 * From the "Favourites" window, select "Options" and use a ViewType of "WideList".
   That's important because we have to move around in the list as if we were
   using arrow keys, and the scripts only move down or up, not left or right.
+
 * Enable the kodi JSONRPC API via HTTP.
     - Settings > Services > Control
     - Set or edit username and password
@@ -33,15 +39,23 @@ PREPARATION
     - The default port is 8080, but you can change it if you want to or need to
     - Allow remote control from applications on other systems
     - Enable SSL if desired (see kodi docs)
+
 * In the ah4c environment, you must configure the kodi password that you created
   just above. See the configuration stuff below.
+
 * If you are running kodi on Android, you must configure adb access
   from the ah4c server machine. If you are running koid on Linux, you
   must configure ssh access from the ah4c server machine to the box
-  running koid. (If you don't know about SSH keys, this article can help
-  you work through it: https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-2)
-  Your are creating an SSH key for the Linux account that runs kodi. For LibreELEC,
-  that account is root. The SSH key is NOT for the JSONRPC account.
+  running kodi. Actually, if you don't attempt to do device
+  sleep/wakeup, force stop, or reboot with the Linux flavor, you
+  probably don't need to configure anything for the SSH access at
+  all. That's probably the case for you. You can just give things a
+  try and look for messages about failed SSH operations in the ah4c
+  log. If you need it, you are creating an SSH key for the Linux
+  account that runs kodi. For LibreELEC, that account is root. The SSH
+  key is NOT for the JSONRPC account. (If you don't know about SSH
+  keys, this article can help you work through it:
+  https://www.digitalocean.com/community/tutorials/how-to-set-up-ssh-keys-2)
 
 NOTE: kodi's spelling is "favourites", not "favorites". That's the
 spelling you should use except as noted specifically below. Also, the

--- a/scripts/chromecast/kodi_faves/bmitune.sh
+++ b/scripts/chromecast/kodi_faves/bmitune.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 FLAVOR=android
-cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-bmitune "$@" 1>&2
+STUB=$(dirname $(dirname $(dirname $(realpath $0))))
+if [[ -z "${STUB}" || "${STUB}" = "/" ]]; then exit 12; fi
+COMMON_DIR=${STUB}/chromecast/kodi_faves
+source ${COMMON_DIR}/common.sh
+DO_THIS=$(basename ${0%.*})
+${DO_THIS} "$@" 1>&2

--- a/scripts/chromecast/kodi_faves/common.sh
+++ b/scripts/chromecast/kodi_faves/common.sh
@@ -5,7 +5,7 @@ set -x
 
 #Trap end of script run
 finish() {
-    echo "$0 is exiting for ${STREAMER_IP} with exit code $?"
+    echo "$0 is exiting for ${STREAMER_NO_PORT} with exit code $?"
 }
 trap finish EXIT
 
@@ -195,7 +195,7 @@ CONFIG_FORCE_STOP_BEFORE_APP_START="false"
 
 ## After tuning a channel, the script waits for the fullscreen player
 ## to actually appear. This is the maximum amount of seconds that it
-## will wait before deciding it's not going to happen. Unless the
+## will wait before deciding it's not going to happen. Unlike the
 ## various "settle" configs, this is not a simple sleep, and the
 ## scaling stuff does not apply. The script checks for the fullscreen
 ## player roughly once a second. It stops looking when it finds it or

--- a/scripts/chromecast/kodi_faves/common.sh
+++ b/scripts/chromecast/kodi_faves/common.sh
@@ -42,11 +42,11 @@ then
     ## for a username on the remote machine. If you are using a
     ## non-standard port, include the options for that here. If you
     ## want to use password authentication, you'll have to organize
-    ## that via SSH ASKPASS, etc.
+    ## that via SSH ASKPASS, etc. The environment variable COMMON_DIR
+    ## points to this directory (where common.sh lives)
     ##
     ## ONLY NEEDED FOR LINUX FLAVOR
-    ## TODO location of ID file
-    CONFIG_KODI_SSH_COMMAND="ssh -i ./id_linuxkodi -l root -o StrictHostKeyChecking=accept-new"
+    CONFIG_KODI_SSH_COMMAND="ssh -i ${COMMON_DIR}/id_linuxkodi -l root -o StrictHostKeyChecking=accept-new"
 fi
 
 if [ ${FLAVOR} = "linux" ]
@@ -311,8 +311,7 @@ then
 fi
 
 ## "config-local.sh" is optional and allows for overriding config values without directly editing the scripts.
-## TODO location of config-local.sh
-CONFIG_LOCAL=`dirname $0`/config-local.sh
+CONFIG_LOCAL=${COMMON_DIR}/config-local.sh
 if [ -f "${CONFIG_LOCAL}" ]
 then
     source "${CONFIG_LOCAL}"

--- a/scripts/chromecast/kodi_faves/common.sh
+++ b/scripts/chromecast/kodi_faves/common.sh
@@ -31,45 +31,57 @@ CONFIG_KODI_JSONRPC_USERNAME="kodi"
 ##
 CONFIG_KODI_JSONRPC_PASSWORD=""
 
-## For android kodi, we use adb, but for Linux kodi, we use ssh for a
-## few things to run shell commands remotely. This is the SSH command
-## for such cases. Everything except the target host name. This will
-## typically include "-i" for an SSH key authentication, and "-l" for
-## a username on the remote machine. If you are using a non-standard
-## port, include the options for that here. If you want to use
-## password authentication, you'll have to organize that via SSH
-## ASKPASS, etc.
-##
-## ONLY NEEDED FOR LINUX FLAVOR
-CONFIG_KODI_SSH_COMMAND="ssh -i ./id_linuxkodi -l root -o StrictHostKeyChecking=accept-new"
+if [ ${FLAVOR} = "linux" ]
+then
+    ## For android kodi, we use adb, but for Linux kodi, we use ssh for a
+    ## few things to run shell commands remotely. This is the SSH command
+    ## for such cases. Everything except the target host name. This will
+    ## typically include "-i" for an SSH key authentication, and "-l" for
+    ## a username on the remote machine. If you are using a non-standard
+    ## port, include the options for that here. If you want to use
+    ## password authentication, you'll have to organize that via SSH
+    ## ASKPASS, etc.
+    ##
+    ## ONLY NEEDED FOR LINUX FLAVOR
+    CONFIG_KODI_SSH_COMMAND="ssh -i ./id_linuxkodi -l root -o StrictHostKeyChecking=accept-new"
+fi
 
-## There are lots of ways to start kodi in Linux environments. Instead
-## of guessing, we ask you to tell us the path or command to something
-## we should call to start kodi. This default value is the start-up
-## script used by LibreELEC. This should be the entire shell command
-## to start kodi.
-##
-## ONLY NEEDED FOR LINUX FLAVOR
-#CONFIG_LINUX_KODI_STARTER="/usr/lib/kodi/kodi.sh"
-## Actually, under LibreELEC, kodi should always be running. Even if you kill it,
-## LibreELEC just spawns it again. So, making this a no-op.
-CONFIG_LINUX_KODI_STARTER="echo 'assuming kodi is always running'"
+if [ ${FLAVOR} = "linux" ]
+then
+    ## There are lots of ways to start kodi in Linux environments. Instead
+    ## of guessing, we ask you to tell us the path or command to something
+    ## we should call to start kodi. This default value is the start-up
+    ## script used by LibreELEC. This should be the entire shell command
+    ## to start kodi.
+    ##
+    ## ONLY NEEDED FOR LINUX FLAVOR
+    #CONFIG_LINUX_KODI_STARTER="/usr/lib/kodi/kodi.sh"
+    ## Actually, under LibreELEC, kodi should always be running. Even if you kill it,
+    ## LibreELEC just spawns it again. So, making this a no-op.
+    CONFIG_LINUX_KODI_STARTER="echo 'assuming kodi is always running'"
+fi
 
-## To do the equivalent of a forced stop on Linux, we have to kill
-## some process. Since there are so many different ways to run kodi,
-## we need to be told what to kill. This should be the entire shell
-## command to kill kodi.
-##
-## ONLY NEEDED FOR LINUX FLAVOR
-CONFIG_LINUX_KODI_STOPPER="killall -KILL kodi.sh"
+if [ ${FLAVOR} = "linux" ]
+then
+    ## To do the equivalent of a forced stop on Linux, we have to kill
+    ## some process. Since there are so many different ways to run kodi,
+    ## we need to be told what to kill. This should be the entire shell
+    ## command to kill kodi.
+    ##
+    ## ONLY NEEDED FOR LINUX FLAVOR
+    CONFIG_LINUX_KODI_STOPPER="killall -KILL kodi.sh"
+fi
 
-## For some Linux installs, like LibreELEC, you will be root and all
-## need is a simple reboot command. For others, you may be some less
-## privileged account and need to do it with "sudo" or some other
-## special sauce.
-##
-## ONLY NEEDED FOR LINUX FLAVOR
-CONFIG_LINUX_KODI_REBOOTER="reboot"
+if [ ${FLAVOR} = "linux" ]
+then
+    ## For some Linux installs, like LibreELEC, you will be root and all
+    ## need is a simple reboot command. For others, you may be some less
+    ## privileged account and need to do it with "sudo" or some other
+    ## special sauce.
+    ##
+    ## ONLY NEEDED FOR LINUX FLAVOR
+    CONFIG_LINUX_KODI_REBOOTER="reboot"
+fi
 
 ## There can be some kodi startup delay (splash screen, etc) before we can
 ## successfully switch to the favouritesbrowser window. Rather than some
@@ -128,16 +140,26 @@ then
     CONFIG_STOP_DOES_DEVICE_SLEEP="false"
 fi
 
+## If you opt to put the device to sleep, you may find it useful to
+## wait for the screen to come back on in the prebmitune.sh
+## step. Regardless, we always check for screen on in the bmitune.sh
+## step. For the Linux flavor, "waking up" can mean deactivating the
+## screensaver. It doesn't take long to deactivate the screensaver,
+## so we don't bother with it in pretune for the Linux flavor.
+##
 if [ ${FLAVOR} = "android" ]
 then
-    ## If you opt to put the device to sleep, you may find it useful to
-    ## wait for the screen to come back on in the prebmitune.sh
-    ## step. Regardless, we always check for screen on in the bmitune.sh
-    ## step.
-    ##
-    ## ONLY NEEDED FOR ANDROID FLAVOR
     CONFIG_PRETUNE_WAIT_FOR_SCREEN="true"
+elif [ ${FLAVOR} = "linux" ]
+then
+    CONFIG_PRETUNE_WAIT_FOR_SCREEN="false"
 fi
+
+## If there is a screensaver, it probably consumes the first keypress
+## to deactivate itself. This probably only applies for Linux flavor
+## but no harm done in using it with Android, too.
+##
+CONFIG_SCREENSAVER_EATS_KEY="true"
 
 ## The app navigation should go OK regardless of where it last was
 ## if it's still running. If for some reason that isn't working
@@ -172,6 +194,17 @@ CONFIG_SETTLE_AFTER_FORCE_STOP="0.25"
 ## between retries.
 ##
 CONFIG_SETTLE_ITERATING_KODI_ACTIVATING_FAVOURITES="1"
+
+## When using JSONRPCs to move up or down the favourites list, settle
+## this amount of teme after each step. I don't know if this is needed,
+## but the small delay doesn't hurt unless the favourites list is huge.
+##
+CONFIG_SETTLE_ITERATING_FAVORITES="0.3"
+
+## After all of the movement in the favourites list is done, settle
+## this amount of time before finally selecting the highlighted item.
+##
+CONFIG_SETTLE_AFTER_NAVIGATING_FAVORITES="1.5"
 
 ###################################################################
 # end of user configuration options ... don't change things below #
@@ -370,6 +403,14 @@ waitForWakeUp() {
     fi
     
     settle ${CONFIG_SETTLE_AFTER_SCREEN_ON}
+    if [ ${CONFIG_SCREENSAVER_EATS_KEY} = "true" ]
+    then
+        # Try as hard as we can to be idempotent. We don't know if the screensaver is actually active.
+        jsonrpc "${J_INPUT_DOWN}"
+        settle ${CONFIG_SETTLE_ITERATING_FAVORITES}
+        jsonrpc "${J_INPUT_UP}"
+        settle ${CONFIG_SETTLE_ITERATING_FAVORITES}
+    fi
 }
 
 
@@ -604,8 +645,10 @@ kodiNavigateFavourites() {
     while [ "$movesRemaining" -gt 0 ]
     do
         jsonrpc "$movementCommand"
+        settle ${CONFIG_SETTLE_ITERATING_FAVORITES}
         ((movesRemaining--))
     done
+    settle ${CONFIG_SETTLE_AFTER_NAVIGATING_FAVORITES}
     jsonrpc "${J_INPUT_SELECT}"
 }
 
@@ -668,7 +711,7 @@ prebmitune() {
         WAKEUP_EXIT_CODE="$?"
     elif [ ${FLAVOR} = "linux" ]
     then
-        #TODO Linux wakeup not implemented
+        : Linux wakeup not implemented
         WAKEUP_EXIT_CODE="0"
     fi
     if [ "${CONFIG_PRETUNE_WAIT_FOR_SCREEN}" = "true" ]

--- a/scripts/chromecast/kodi_faves/common.sh
+++ b/scripts/chromecast/kodi_faves/common.sh
@@ -199,12 +199,12 @@ CONFIG_SETTLE_ITERATING_KODI_ACTIVATING_FAVOURITES="1"
 ## this amount of teme after each step. I don't know if this is needed,
 ## but the small delay doesn't hurt unless the favourites list is huge.
 ##
-CONFIG_SETTLE_ITERATING_FAVORITES="0.3"
+CONFIG_SETTLE_ITERATING_FAVORITES="0.1"
 
 ## After all of the movement in the favourites list is done, settle
 ## this amount of time before finally selecting the highlighted item.
 ##
-CONFIG_SETTLE_AFTER_NAVIGATING_FAVORITES="1.5"
+CONFIG_SETTLE_AFTER_NAVIGATING_FAVORITES="0.5"
 
 ###################################################################
 # end of user configuration options ... don't change things below #
@@ -563,23 +563,20 @@ kodiActivateFavourites() {
     local -i tryCounter=0
     while true
     do
-        jsonrpc "${J_ACTIVATE_FAVOURITES}"
-        if [ "$?" == 0 ]
-        then
-            local window=`kodiGetCurrentWindowId`
-            echo "Current window is '${window}'"
-            if [ "${window}" = "${KODI_FAVOURITES_WINDOW_ID}" ]
-               then
-                   echo "Favourites window is activated"
-                   break
-            fi
-        fi
-        
         if ((${tryCounter} > ${CONFIG_KODI_FAVOURITES_ITERATING_MAX})); then
             touch $STREAMER_NO_PORT/adbCommunicationFail
             echo "Activating favourites window on ${STREAMER_WITH_PORT} failed after ${CONFIG_KODI_FAVOURITES_ITERATING_MAX} tries"
             forceStopAndExit 1
         fi
+        local window=`kodiGetCurrentWindowId`
+        echo "Current window is '${window}'"
+        if [ "${window}" = "${KODI_FAVOURITES_WINDOW_ID}" ]
+        then
+            echo "Favourites window is activated"
+            break
+        fi
+        jsonrpc "${J_ACTIVATE_FAVOURITES}"
+        
         ((tryCounter++))
         settle ${CONFIG_SETTLE_ITERATING_KODI_ACTIVATING_FAVOURITES}
     done

--- a/scripts/chromecast/kodi_faves/common.sh
+++ b/scripts/chromecast/kodi_faves/common.sh
@@ -250,6 +250,8 @@ fi
 J_ACTIVATE_FAVOURITES='{"jsonrpc": "2.0", "method": "GUI.ActivateWindow", "params": {"window": "favouritesbrowser"}, "id": 1}'
 J_INPUT_DOWN='{"jsonrpc": "2.0", "method": "Input.Down", "id": 1}'
 J_INPUT_UP='{"jsonrpc": "2.0", "method": "Input.Up", "id": 1}'
+J_INPUT_RIGHT='{"jsonrpc": "2.0", "method": "Input.Right", "id": 1}'
+J_INPUT_LEFT='{"jsonrpc": "2.0", "method": "Input.Left", "id": 1}'
 J_INPUT_SELECT='{"jsonrpc": "2.0", "method": "Input.Select", "id": 1}'
 J_INPUT_BACK='{"jsonrpc": "2.0", "method": "Input.Back", "id": 1}'
 J_APPLICATION_QUIT='{"jsonrpc": "2.0", "method": "Application.Quit", "id": 1}'
@@ -405,11 +407,12 @@ waitForWakeUp() {
     settle ${CONFIG_SETTLE_AFTER_SCREEN_ON}
     if [ ${CONFIG_SCREENSAVER_EATS_KEY} = "true" ]
     then
-        # Try as hard as we can to be idempotent. We don't know if the screensaver is actually active.
-        jsonrpc "${J_INPUT_DOWN}"
-        settle ${CONFIG_SETTLE_ITERATING_FAVORITES}
-        jsonrpc "${J_INPUT_UP}"
-        settle ${CONFIG_SETTLE_ITERATING_FAVORITES}
+        # We don't know if the screensaver is actually active.  By
+        # using "right", which has no effect on the WideList view of
+        # the favourites screen, it avoids a little screen flashing.
+        # If we're on some other screen, we don't care what "right"
+        # does (I hope :-) )
+        jsonrpc "${J_INPUT_RIGHT}"
     fi
 }
 

--- a/scripts/chromecast/kodi_faves/common.sh
+++ b/scripts/chromecast/kodi_faves/common.sh
@@ -257,6 +257,36 @@ J_INPUT_BACK='{"jsonrpc": "2.0", "method": "Input.Back", "id": 1}'
 J_APPLICATION_QUIT='{"jsonrpc": "2.0", "method": "Application.Quit", "id": 1}'
 J_PLAYER_STOP='{"jsonrpc": "2.0", "method": "Player.Stop", "params": {"playerid": PLAYERID}, "id": 1}'
 
+# NOTE: I recently found out how to directly tune an item from the favourites list, but it's not
+# implemented here. See examples just below. Take the value of the "path" attribute and wrap it in a
+# PlayMedia action. Invoke that via the kodi python API. If the value of the "path" attribute is
+# "PPPPP", it would look like:
+#
+#   kodi-send --action='PlayMedia(PPPPP)'
+#
+# where "kodi-send" is a command for sending things to the python API. "kodi-send" is a standard
+# part of kodi and is python, so it should be available on all platforms, I guess. It took me some
+# sleuthing and guessing, but I finally figured out how to do this in JSONRPC. I had tried that
+# without joy a million years ago, but just today I got it to work by substituting the attribute
+# name "file" where I previously had "path".
+#
+# I'm going to think about implementing this. It's better in the script logic than navigating the
+# favorites menu, but it's not so obvious where a non-technical user would dig out the real values of
+# "PPPPP", nor where is the best way to keep track of things.
+#
+#{
+#    "jsonrpc": "2.0",
+#    "method": "Player.Open",
+#    "params":
+#    {
+#        "item":
+#        {
+#            "file": "PPPPP"
+#        }
+#    },
+#    "id": 1
+#}
+#
 J_GET_FAVES='{"jsonrpc": "2.0", "method": "Favourites.GetFavourites", "id": 1}'
 # {
 #   "id": 1,

--- a/scripts/chromecast/kodi_faves/prebmitune.sh
+++ b/scripts/chromecast/kodi_faves/prebmitune.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 FLAVOR=android
-cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-prebmitune "$@" 1>&2
+STUB=$(dirname $(dirname $(dirname $(realpath $0))))
+if [[ -z "${STUB}" || "${STUB}" = "/" ]]; then exit 12; fi
+COMMON_DIR=${STUB}/chromecast/kodi_faves
+source ${COMMON_DIR}/common.sh
+DO_THIS=$(basename ${0%.*})
+${DO_THIS} "$@" 1>&2

--- a/scripts/chromecast/kodi_faves/prebmitune.sh
+++ b/scripts/chromecast/kodi_faves/prebmitune.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-. `dirname $0`/common.sh
+FLAVOR=android
+cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
 prebmitune "$@" 1>&2

--- a/scripts/chromecast/kodi_faves/stopbmitune.sh
+++ b/scripts/chromecast/kodi_faves/stopbmitune.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 FLAVOR=android
-cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-stopbmitune "$@" 1>&2
+STUB=$(dirname $(dirname $(dirname $(realpath $0))))
+if [[ -z "${STUB}" || "${STUB}" = "/" ]]; then exit 12; fi
+COMMON_DIR=${STUB}/chromecast/kodi_faves
+source ${COMMON_DIR}/common.sh
+DO_THIS=$(basename ${0%.*})
+${DO_THIS} "$@" 1>&2

--- a/scripts/chromecast/kodi_faves/stopbmitune.sh
+++ b/scripts/chromecast/kodi_faves/stopbmitune.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-. `dirname $0`/common.sh
+FLAVOR=android
+cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
 stopbmitune "$@" 1>&2

--- a/scripts/linux/kodi/README.txt
+++ b/scripts/linux/kodi/README.txt
@@ -2,13 +2,12 @@ A tuner for kodi favourites list
 
 This set of scripts shares commonality with the scripts under
 scripts/chromecast/kodi_faves/. See the README.txt under there for
-important details.
+important details, configuration options, etc.
 
 This should work on any sort of Linux box that can run kodi. I tested
 it with a few distributions before I settled on one called
-LibreELEC. I tried it on a few differnt Raspberry Pi boards that I had
-on hand. You can find LibreELEC among the media players in the
-standard RPi imager tool.
+plain old raspbian. I tried it on a few differnt Raspberry Pi boards that I had
+on hand.
 
 On a couple of RPi 1 boards, the lag and stutter was pretty bad. On an
 RPi 2 board with 1 GB of RAM, playing was mostly smooth but with

--- a/scripts/linux/kodi/README.txt
+++ b/scripts/linux/kodi/README.txt
@@ -1,0 +1,20 @@
+A tuner for kodi favourites list
+
+This set of scripts shares commonality with the scripts under
+scripts/chromecast/kodi_faves/. See the README.txt under there for
+important details.
+
+This should work on any sort of Linux box that can run kodi. I tested
+it with a few distributions before I settled on one called
+LibreELEC. I tried it on a few differnt Raspberry Pi boards that I had
+on hand. You can find LibreELEC among the media players in the
+standard RPi imager tool.
+
+On a couple of RPi 1 boards, the lag and stutter was pretty bad. On an
+RPi 2 board with 1 GB of RAM, playing was mostly smooth but with
+occasional lag and stutter. On an RPi 3B+ with 1 GB of RAM, playback
+was completely smooth for 1080p/60fps. An 8gb microSD card is way more
+than enough to hold the image and kodi addons. Of course, you have to
+decide if running from a microSD card is too risky. If you run from a
+USB thumb drive, navigation may be a bit sluggish but playback should
+be unaffected.

--- a/scripts/linux/kodi/bmitune.sh
+++ b/scripts/linux/kodi/bmitune.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-FLAVOR=android
+FLAVOR=linux
 cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
 bmitune "$@" 1>&2

--- a/scripts/linux/kodi/bmitune.sh
+++ b/scripts/linux/kodi/bmitune.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 FLAVOR=linux
-cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-bmitune "$@" 1>&2
+STUB=$(dirname $(dirname $(dirname $(realpath $0))))
+if [[ -z "${STUB}" || "${STUB}" = "/" ]]; then exit 12; fi
+COMMON_DIR=${STUB}/chromecast/kodi_faves
+source ${COMMON_DIR}/common.sh
+DO_THIS=$(basename ${0%.*})
+${DO_THIS} "$@" 1>&2

--- a/scripts/linux/kodi/prebmitune.sh
+++ b/scripts/linux/kodi/prebmitune.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 FLAVOR=linux
-cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-prebmitune "$@" 1>&2
+STUB=$(dirname $(dirname $(dirname $(realpath $0))))
+if [[ -z "${STUB}" || "${STUB}" = "/" ]]; then exit 12; fi
+COMMON_DIR=${STUB}/chromecast/kodi_faves
+source ${COMMON_DIR}/common.sh
+DO_THIS=$(basename ${0%.*})
+${DO_THIS} "$@" 1>&2

--- a/scripts/linux/kodi/prebmitune.sh
+++ b/scripts/linux/kodi/prebmitune.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-FLAVOR=android
+FLAVOR=linux
 cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-bmitune "$@" 1>&2
+prebmitune "$@" 1>&2

--- a/scripts/linux/kodi/stopbmitune.sh
+++ b/scripts/linux/kodi/stopbmitune.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 FLAVOR=linux
-cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-stopbmitune "$@" 1>&2
+STUB=$(dirname $(dirname $(dirname $(realpath $0))))
+if [[ -z "${STUB}" || "${STUB}" = "/" ]]; then exit 12; fi
+COMMON_DIR=${STUB}/chromecast/kodi_faves
+source ${COMMON_DIR}/common.sh
+DO_THIS=$(basename ${0%.*})
+${DO_THIS} "$@" 1>&2

--- a/scripts/linux/kodi/stopbmitune.sh
+++ b/scripts/linux/kodi/stopbmitune.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-FLAVOR=android
+FLAVOR=linux
 cd `dirname $0`/../../chromecast/kodi_faves && source common.sh
-bmitune "$@" 1>&2
+stopbmitune "$@" 1>&2


### PR DESCRIPTION
This provides scripts/linux/kodi/ for running kodi on pretty much any flavor of linux on any hardware (tested extensively and almost exclusively on RPis). In addition to that, there are numerous improvements to the original scripts/chromecast/kodi_faves. One of the biggest improvements is the ability to directly play an item from the Favourites list without navigating up or down in that list.