### PR TITLE
Osprey Deeplinks "am start" and deeplink quoting fix/Keep Watching Support for Osprey Boxes

### DIFF
--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 # bmitune.sh for osprey/dtvospreydeeplinks
-# 2025.09.26
-
+# 2026.04.03
 #Debug on if uncommented
 set -x
-
 #Global
 channelID=$(echo $1 | awk -F~ '{print $2}')
 channelName=$(echo $1 | awk -F~ '{print $1}')
@@ -14,16 +12,16 @@ streamerNoPort="${streamerIP%%:*}"
 adbTarget="adb -s $streamerIP"
 [[ $SPEED_MODE == "" ]] && speedMode="true" || speedMode="$SPEED_MODE"
 
+mkdir -p $streamerNoPort
+echo $$ > "$streamerNoPort/bmitune_pid"
+
 #Trap end of script run
 finish() {
   echo "bmitune.sh is exiting for $streamerIP with exit code $?"
 }
-
 trap finish EXIT
-
 #Set encoderURL based on the value of streamerIP
 matchEncoderURL() {
-
   case "$streamerIP" in
     "$TUNER1_IP")
         encoderURL=$ENCODER1_URL
@@ -57,15 +55,13 @@ matchEncoderURL() {
         ;;
   esac
 }
-
 #Tuning is based on channel name/ID values from dtvospreydeeplinks.m3u.
 tuneChannel() {
-  #$adbTarget shell am start -a android.intent.action.VIEW -d https://deeplink.directvnow.com/tune/live/$channelName/$channelID
-  $adbTarget shell am start -W -a android.intent.action.VIEW -d https://deeplink.directvnow.com/tune/live/channel/$channelName/$channelID com.att.tv.openvideo
+  $adbTarget shell "am start -a android.intent.action.VIEW -d 'https://deeplink.directvnow.com/tune/live/channel/$channelName/$channelID' com.att.tv.openvideo"
+  echo -e "#!/bin/bash\n\necho \"[\$(date)] Keep-alive started for $streamerIP (interval: $KEEP_WATCHING)\" > /proc/1/fd/1\nwhile true; do sleep $KEEP_WATCHING; echo \"[\$(date)] Keep-alive sent to $streamerIP\" > /proc/1/fd/1; $adbTarget shell input keyevent KEYCODE_MEDIA_PLAY; done" > ./$streamerNoPort/keep_watching.sh && chmod +x ./$streamerNoPort/keep_watching.sh
+  [[ $KEEP_WATCHING ]] && nohup ./$streamerNoPort/keep_watching.sh &
 }
-
 main() {
   tuneChannel
 }
-
 main

--- a/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
 # stopbmitune.sh for osprey/dtvospreydeeplinks
-# 2025.09.26
-
+# 2026.04.03
 #Debug on if uncommented
 set -x
 
 streamerIP="$1"
 streamerNoPort="${streamerIP%%:*}"
 adbTarget="adb -s $streamerIP"
+
+#Check if bmitune.sh is done running
+bmituneDone() {
+  bmitunePID=$(<"$streamerNoPort/bmitune_pid")
+  keepWatchingPID=$(pgrep -f "$streamerNoPort/keep_watching.sh")
+  keepWatchingPPID=$(ps -o ppid= -p "$keepWatchingPID")
+  keepWatchingCPID=$(pgrep -P $keepWatchingPID)
+
+  while ps -p $bmitunePID > /dev/null; do
+    echo "Waiting for bmitune.sh to complete..."
+    sleep 2
+  done
+
+  [[ $KEEP_WATCHING ]] && pkill -P $keepWatchingPPID && kill $keepWatchingCPID
+  rm ./$streamerNoPort/keep_watching.sh
+}
 
 #Device sleep
 adbSleep() {
@@ -19,7 +34,7 @@ adbSleep() {
 }
 
 main() {
+  bmituneDone
   adbSleep
 }
-
 main


### PR DESCRIPTION
This is intended for users who want their boxes to sleep using the default 4h timeout but not sleep during a long viewing session. This way if an Osprey is powered on accidentally it will naturally shut off using the power save feature. It works by sending `KEYCODE_MEDIA_PLAY` which does nothing on screen but acts as a heartbeat that prevents the box from sleeping or any "are you still there" prompts from appearing. I was able to watch for over 6 hours with zero interruptions.

Also updated `bmitune.sh` with quoting for channel names with spaces so they tune:
```
$adbTarget shell "am start -a android.intent.action.VIEW -d 'https://deeplink.directvnow.com/tune/live/channel/$channelName/$channelID' com.att.tv.openvideo"
```
DirecTV seems to be adding spaces to some channel names now which can cause deeplinks to fail.