### PR TITLE
(fix) Tuning fails after rebooting HDMI encoder

### DIFF
--- a/main.go
+++ b/main.go
@@ -1374,11 +1374,12 @@ type stallTolerantReader struct {
 }
 
 const (
-	stallReadGap       = 500 * time.Millisecond  // queue-empty before injecting nulls
-	srcStallReconnect  = 5 * time.Second         // source idle before forced reconnect
-	srcReconnectBackoff = 2 * time.Second        // wait between failed reconnect attempts
-	chunkSize          = 32 * 1024
-	queueDepth         = 64 // ~2MB max in-flight
+	stallReadGap         = 500 * time.Millisecond // queue-empty before injecting nulls
+	srcStallReconnect    = 5 * time.Second        // source idle before forced reconnect
+	srcReconnectBackoff  = 2 * time.Second        // wait between failed reconnect attempts
+	maxUnhealthyDuration = 15 * time.Second       // total time without any real bytes before giving up so Read returns EOF and DVR can react (matches Channels DVR's no-data timeout)
+	chunkSize            = 32 * 1024
+	queueDepth           = 64 // ~2MB max in-flight
 )
 
 func newStallTolerantReader(body io.ReadCloser, reconnectFn func() (io.ReadCloser, error), label string) *stallTolerantReader {
@@ -1395,11 +1396,20 @@ func newStallTolerantReader(body io.ReadCloser, reconnectFn func() (io.ReadClose
 
 func (s *stallTolerantReader) producer() {
 	chunk := make([]byte, chunkSize)
+	lastRealBytes := time.Now()
+	giveUp := func(reason string) {
+		logger("[%s] %s; closing reader so DVR sees EOF", s.label, reason)
+		s.closeOnce.Do(func() { close(s.closed) })
+	}
 	for {
 		select {
 		case <-s.closed:
 			return
 		default:
+		}
+		if time.Since(lastRealBytes) > maxUnhealthyDuration {
+			giveUp(fmt.Sprintf("no source bytes for %v", maxUnhealthyDuration))
+			return
 		}
 		s.bodyMu.Lock()
 		body := s.body
@@ -1408,6 +1418,7 @@ func (s *stallTolerantReader) producer() {
 		n, err := readWithDeadline(ctx, body, chunk)
 		cancel()
 		if n > 0 {
+			lastRealBytes = time.Now()
 			data := make([]byte, n)
 			copy(data, chunk[:n])
 			select {
@@ -1429,12 +1440,19 @@ func (s *stallTolerantReader) producer() {
 			return
 		}
 		// Try to reconnect. While this loops, DVR keeps getting NULL packets.
+		// The outer-loop budget check handles the "reconnect succeeds repeatedly
+		// but yields no real bytes" case; this inner check handles "reconnect
+		// keeps failing outright".
 		var newBody io.ReadCloser
 		for {
 			select {
 			case <-s.closed:
 				return
 			default:
+			}
+			if time.Since(lastRealBytes) > maxUnhealthyDuration {
+				giveUp(fmt.Sprintf("no source bytes for %v during reconnect", maxUnhealthyDuration))
+				return
 			}
 			nb, rerr := s.reconnectFn()
 			if rerr == nil {

--- a/main.go
+++ b/main.go
@@ -401,23 +401,27 @@ func tune(idx, channel string) (io.ReadCloser, error) {
 				t.active = false
 				continue
 			}
-			// Wrap the encoder body so DVR sees a continuous byte stream even if
-			// the encoder briefly stalls during the bmitune.sh channel change or
-			// has to be reconnected. Stalls are filled with MPEG-TS NULL packets
-			// (PID 0x1FFF) which TS demuxers ignore. Warm path adds zero latency.
-			encoderURL := t.url
-			tunerLabel := fmt.Sprintf("tuner=%s", t.tunerip)
-			body := newStallTolerantReader(resp.Body, func() (io.ReadCloser, error) {
-				r, e := http.Get(encoderURL)
-				if e != nil {
-					return nil, e
-				}
-				if r.StatusCode != 200 {
-					r.Body.Close()
-					return nil, fmt.Errorf("status %s", r.Status)
-				}
-				return r.Body, nil
-			}, tunerLabel)
+			// Opt-in via NULL_FRAME_INSERTION=TRUE: wrap the encoder body so DVR
+			// sees a continuous byte stream even if the encoder briefly stalls
+			// during the bmitune.sh channel change or has to be reconnected.
+			// Stalls are filled with MPEG-TS NULL packets (PID 0x1FFF) which
+			// TS demuxers ignore. Default is the original pass-through.
+			var body io.ReadCloser = resp.Body
+			if os.Getenv("NULL_FRAME_INSERTION") == "TRUE" {
+				encoderURL := t.url
+				tunerLabel := fmt.Sprintf("tuner=%s", t.tunerip)
+				body = newStallTolerantReader(resp.Body, func() (io.ReadCloser, error) {
+					r, e := http.Get(encoderURL)
+					if e != nil {
+						return nil, e
+					}
+					if r.StatusCode != 200 {
+						r.Body.Close()
+						return nil, fmt.Errorf("status %s", r.Status)
+					}
+					return r.Body, nil
+				}, tunerLabel)
+			}
 			t.active = true
 			t.index = i
 			r := &reader{
@@ -979,6 +983,7 @@ func loadenv() {
 	logger("[ENV] ALERT_EMAIL_TO             %s", os.Getenv("ALERT_EMAIL_TO"))
 	logger("[ENV] ALERT_WEBHOOK_URL          %s", os.Getenv("ALERT_WEBHOOK_URL"))
 	logger("[ENV] ALLOW_DEBUG_VIDEO_PREVIEW  %s", os.Getenv("ALLOW_DEBUG_VIDEO_PREVIEW"))
+	logger("[ENV] NULL_FRAME_INSERTION       %s", os.Getenv("NULL_FRAME_INSERTION"))
 	// Retrieve the number of tuners from the environment variable "NUMBER_TUNERS".
 	// This value represents the number of distinct tuners that the program will manage.
 	numTunersStr := os.Getenv("NUMBER_TUNERS")

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"html/template"
 	"io"
@@ -384,6 +385,11 @@ func tune(idx, channel string) (io.ReadCloser, error) {
 			}
 			// Network encoder
 			logger("Attempting network tune for device %s %s %v %v", t.url, t.tunerip, channel, idx)
+			if err := execute(t.pre, t.tunerip, channel); err != nil {
+				logger("[ERR] Failed to run pre script: %v %s", err, t.tunerip)
+				t.active = false
+				continue
+			}
 			resp, err := http.Get(t.url)
 			if err != nil {
 				logger("[ERR] Failed to fetch source: %v", err)
@@ -391,21 +397,35 @@ func tune(idx, channel string) (io.ReadCloser, error) {
 				continue
 			} else if resp.StatusCode != 200 {
 				logger("[ERR] Failed to fetch source: %v", resp.Status)
+				resp.Body.Close()
 				t.active = false
 				continue
 			}
-			if err := execute(t.pre, t.tunerip, channel); err != nil {
-				logger("[ERR] Failed to run pre script: %v %s", err, t.tunerip)
-				t.active = false
-				continue
-			}
+			// Wrap the encoder body so DVR sees a continuous byte stream even if
+			// the encoder briefly stalls during the bmitune.sh channel change or
+			// has to be reconnected. Stalls are filled with MPEG-TS NULL packets
+			// (PID 0x1FFF) which TS demuxers ignore. Warm path adds zero latency.
+			encoderURL := t.url
+			tunerLabel := fmt.Sprintf("tuner=%s", t.tunerip)
+			body := newStallTolerantReader(resp.Body, func() (io.ReadCloser, error) {
+				r, e := http.Get(encoderURL)
+				if e != nil {
+					return nil, e
+				}
+				if r.StatusCode != 200 {
+					r.Body.Close()
+					return nil, fmt.Errorf("status %s", r.Status)
+				}
+				return r.Body, nil
+			}, tunerLabel)
 			t.active = true
 			t.index = i
-			return &reader{
-				ReadCloser: resp.Body,
+			r := &reader{
+				ReadCloser: body,
 				channel:    channel,
 				t:          t,
-			}, nil
+			}
+			return r, nil
 		}
 	}
 	return nil, fmt.Errorf("device(s) not available")
@@ -1311,5 +1331,181 @@ func saveConfigToFile(filePath string, configData ConfigData) {
 	if err != nil {
 		log.Printf("Failed to write to file: %s", err)
 		os.Exit(1)
+	}
+}
+
+// nullTSPacket is a single 188-byte MPEG-TS NULL packet (PID 0x1FFF). TS
+// demuxers including Channels DVR drop these on demux, so they're safe to
+// inject as a keepalive when the upstream encoder briefly stops producing.
+var nullTSPacket = func() [188]byte {
+	var p [188]byte
+	p[0] = 0x47 // sync byte
+	p[1] = 0x1F // TEI=0, PUSI=0, transport_priority=0, PID upper 5 bits = 0x1F
+	p[2] = 0xFF // PID lower 8 bits (full PID = 0x1FFF)
+	p[3] = 0x10 // scrambling=0, adaptation_field_control=01 (payload only), CC=0
+	for i := 4; i < 188; i++ {
+		p[i] = 0xFF
+	}
+	return p
+}()
+
+// stallTolerantReader wraps an HTTP response body so that downstream consumers
+// (Channels DVR) never observe a zero-byte gap when the upstream encoder
+// stalls (e.g. while bmitune.sh triggers a channel change) or when the
+// underlying TCP connection dies and needs to be re-established.
+//
+// Behavior:
+//   - A producer goroutine reads from the source and pushes chunks into a
+//     bounded queue.
+//   - Read() drains the queue; if the queue is empty for stallReadGap, it fills
+//     the caller's buffer with TS NULL packets so the HTTP response keeps
+//     making forward progress.
+//   - If the source produces nothing for srcStallReconnect, the producer closes
+//     the body, calls reconnectFn, and continues with the new body. NULL
+//     packets keep DVR fed during the reconnect.
+type stallTolerantReader struct {
+	chunks      chan []byte
+	closed      chan struct{}
+	closeOnce   sync.Once
+	bodyMu      sync.Mutex
+	body        io.ReadCloser
+	reconnectFn func() (io.ReadCloser, error)
+	label       string
+}
+
+const (
+	stallReadGap       = 500 * time.Millisecond  // queue-empty before injecting nulls
+	srcStallReconnect  = 5 * time.Second         // source idle before forced reconnect
+	srcReconnectBackoff = 2 * time.Second        // wait between failed reconnect attempts
+	chunkSize          = 32 * 1024
+	queueDepth         = 64 // ~2MB max in-flight
+)
+
+func newStallTolerantReader(body io.ReadCloser, reconnectFn func() (io.ReadCloser, error), label string) *stallTolerantReader {
+	s := &stallTolerantReader{
+		chunks:      make(chan []byte, queueDepth),
+		closed:      make(chan struct{}),
+		body:        body,
+		reconnectFn: reconnectFn,
+		label:       label,
+	}
+	go s.producer()
+	return s
+}
+
+func (s *stallTolerantReader) producer() {
+	chunk := make([]byte, chunkSize)
+	for {
+		select {
+		case <-s.closed:
+			return
+		default:
+		}
+		s.bodyMu.Lock()
+		body := s.body
+		s.bodyMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), srcStallReconnect)
+		n, err := readWithDeadline(ctx, body, chunk)
+		cancel()
+		if n > 0 {
+			data := make([]byte, n)
+			copy(data, chunk[:n])
+			select {
+			case s.chunks <- data:
+			case <-s.closed:
+				return
+			}
+			if err == nil {
+				continue
+			}
+		}
+		// n == 0 OR err != nil after partial read.
+		if err != nil {
+			logger("[%s] source idle/error (%v); reconnecting", s.label, err)
+		}
+		body.Close()
+		if s.reconnectFn == nil {
+			s.closeOnce.Do(func() { close(s.closed) })
+			return
+		}
+		// Try to reconnect. While this loops, DVR keeps getting NULL packets.
+		var newBody io.ReadCloser
+		for {
+			select {
+			case <-s.closed:
+				return
+			default:
+			}
+			nb, rerr := s.reconnectFn()
+			if rerr == nil {
+				newBody = nb
+				break
+			}
+			logger("[%s] reconnect failed: %v", s.label, rerr)
+			select {
+			case <-time.After(srcReconnectBackoff):
+			case <-s.closed:
+				return
+			}
+		}
+		logger("[%s] reconnected", s.label)
+		s.bodyMu.Lock()
+		s.body = newBody
+		s.bodyMu.Unlock()
+	}
+}
+
+func (s *stallTolerantReader) Read(p []byte) (int, error) {
+	timer := time.NewTimer(stallReadGap)
+	defer timer.Stop()
+	select {
+	case <-s.closed:
+		return 0, io.EOF
+	case data := <-s.chunks:
+		return copy(p, data), nil
+	case <-timer.C:
+		// Stalled — fill p with NULL packets to keep DVR's connection alive.
+		n := 0
+		for n+188 <= len(p) {
+			copy(p[n:n+188], nullTSPacket[:])
+			n += 188
+		}
+		if n == 0 {
+			// p < 188 bytes — return what fits
+			return copy(p, nullTSPacket[:]), nil
+		}
+		return n, nil
+	}
+}
+
+func (s *stallTolerantReader) Close() error {
+	s.closeOnce.Do(func() { close(s.closed) })
+	s.bodyMu.Lock()
+	body := s.body
+	s.bodyMu.Unlock()
+	if body != nil {
+		return body.Close()
+	}
+	return nil
+}
+
+// readWithDeadline performs r.Read(buf) with a context deadline. If the
+// deadline elapses, it returns (0, ctx.Err()) — the caller is expected to
+// close the underlying reader to release the leaked goroutine.
+func readWithDeadline(ctx context.Context, r io.Reader, buf []byte) (int, error) {
+	type result struct {
+		n   int
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		n, err := r.Read(buf)
+		ch <- result{n, err}
+	}()
+	select {
+	case res := <-ch:
+		return res.n, res.err
+	case <-ctx.Done():
+		return 0, ctx.Err()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -401,17 +402,11 @@ func tune(idx, channel string) (io.ReadCloser, error) {
 				t.active = false
 				continue
 			}
-			// Opt-in via NULL_FRAME_INSERTION=TRUE: wrap the encoder body so DVR
-			// sees a continuous byte stream even if the encoder briefly stalls
-			// during the bmitune.sh channel change or has to be reconnected.
-			// Stalls are filled with MPEG-TS NULL packets (PID 0x1FFF) which
-			// TS demuxers ignore. Default is the original pass-through.
+			// NULL_FRAME_INSERTION=TRUE: fill encoder stalls with MPEG-TS NULLs so DVR never sees a zero-byte gap.
 			var body io.ReadCloser = resp.Body
 			if os.Getenv("NULL_FRAME_INSERTION") == "TRUE" {
-				encoderURL := t.url
-				tunerLabel := fmt.Sprintf("tuner=%s", t.tunerip)
 				body = newStallTolerantReader(resp.Body, func() (io.ReadCloser, error) {
-					r, e := http.Get(encoderURL)
+					r, e := http.Get(t.url)
 					if e != nil {
 						return nil, e
 					}
@@ -420,7 +415,7 @@ func tune(idx, channel string) (io.ReadCloser, error) {
 						return nil, fmt.Errorf("status %s", r.Status)
 					}
 					return r.Body, nil
-				}, tunerLabel)
+				}, fmt.Sprintf("tuner=%s", t.tunerip))
 			}
 			t.active = true
 			t.index = i
@@ -1339,52 +1334,39 @@ func saveConfigToFile(filePath string, configData ConfigData) {
 	}
 }
 
-// nullTSPacket is a single 188-byte MPEG-TS NULL packet (PID 0x1FFF). TS
-// demuxers including Channels DVR drop these on demux, so they're safe to
-// inject as a keepalive when the upstream encoder briefly stops producing.
+// nullTSPacket is an MPEG-TS NULL packet (PID 0x1FFF) — safe keepalive bytes.
 var nullTSPacket = func() [188]byte {
 	var p [188]byte
-	p[0] = 0x47 // sync byte
-	p[1] = 0x1F // TEI=0, PUSI=0, transport_priority=0, PID upper 5 bits = 0x1F
-	p[2] = 0xFF // PID lower 8 bits (full PID = 0x1FFF)
-	p[3] = 0x10 // scrambling=0, adaptation_field_control=01 (payload only), CC=0
-	for i := 4; i < 188; i++ {
-		p[i] = 0xFF
-	}
+	p[0], p[1], p[2], p[3] = 0x47, 0x1F, 0xFF, 0x10
+	copy(p[4:], bytes.Repeat([]byte{0xFF}, 184))
 	return p
 }()
 
-// stallTolerantReader wraps an HTTP response body so that downstream consumers
-// (Channels DVR) never observe a zero-byte gap when the upstream encoder
-// stalls (e.g. while bmitune.sh triggers a channel change) or when the
-// underlying TCP connection dies and needs to be re-established.
-//
-// Behavior:
-//   - A producer goroutine reads from the source and pushes chunks into a
-//     bounded queue.
-//   - Read() drains the queue; if the queue is empty for stallReadGap, it fills
-//     the caller's buffer with TS NULL packets so the HTTP response keeps
-//     making forward progress.
-//   - If the source produces nothing for srcStallReconnect, the producer closes
-//     the body, calls reconnectFn, and continues with the new body. NULL
-//     packets keep DVR fed during the reconnect.
+// nullFill is a pre-assembled run of NULL packets for one-shot stall fills.
+var nullFill = bytes.Repeat(nullTSPacket[:], 350) // 65.8KB, ≥ any plausible DVR read
+
+// stallTolerantReader fills encoder stalls with NULL TS packets. NULLs are
+// gated behind the first real chunk so DVR locks onto the real PAT/PMT.
 type stallTolerantReader struct {
-	chunks      chan []byte
-	closed      chan struct{}
-	closeOnce   sync.Once
-	bodyMu      sync.Mutex
-	body        io.ReadCloser
-	reconnectFn func() (io.ReadCloser, error)
-	label       string
+	chunks        chan []byte
+	closed        chan struct{}
+	closeOnce     sync.Once
+	bodyMu        sync.Mutex
+	body          io.ReadCloser
+	reconnectFn   func() (io.ReadCloser, error)
+	label         string
+	hasFirstChunk atomic.Bool
 }
 
 const (
-	stallReadGap         = 500 * time.Millisecond // queue-empty before injecting nulls
-	srcStallReconnect    = 5 * time.Second        // source idle before forced reconnect
-	srcReconnectBackoff  = 2 * time.Second        // wait between failed reconnect attempts
-	maxUnhealthyDuration = 15 * time.Second       // total time without any real bytes before giving up so Read returns EOF and DVR can react (matches Channels DVR's no-data timeout)
+	stallReadGap         = 500 * time.Millisecond
+	srcStallReconnect    = 5 * time.Second
+	srcReconnectBackoff  = 2 * time.Second
+	reconnectLogEvery    = 10 * time.Second
+	preFirstChunkBudget  = 15 * time.Second // fail over fast on a dead tuner
+	postFirstChunkBudget = 3 * time.Minute  // ride through mid-stream glitches
 	chunkSize            = 32 * 1024
-	queueDepth           = 64 // ~2MB max in-flight
+	queueDepth           = 64
 )
 
 func newStallTolerantReader(body io.ReadCloser, reconnectFn func() (io.ReadCloser, error), label string) *stallTolerantReader {
@@ -1401,29 +1383,53 @@ func newStallTolerantReader(body io.ReadCloser, reconnectFn func() (io.ReadClose
 
 func (s *stallTolerantReader) producer() {
 	chunk := make([]byte, chunkSize)
-	lastRealBytes := time.Now()
-	giveUp := func(reason string) {
-		logger("[%s] %s; closing reader so DVR sees EOF", s.label, reason)
-		s.closeOnce.Do(func() { close(s.closed) })
-	}
+	lastReal := time.Now()
+	var lastLog time.Time
 	for {
 		select {
 		case <-s.closed:
 			return
 		default:
 		}
-		if time.Since(lastRealBytes) > maxUnhealthyDuration {
-			giveUp(fmt.Sprintf("no source bytes for %v", maxUnhealthyDuration))
+		budget := preFirstChunkBudget
+		if s.hasFirstChunk.Load() {
+			budget = postFirstChunkBudget
+		}
+		if time.Since(lastReal) > budget {
+			logger("[%s] no source bytes for %v; giving up and ending stream", s.label, budget)
+			s.closeOnce.Do(func() { close(s.closed) })
 			return
 		}
 		s.bodyMu.Lock()
 		body := s.body
 		s.bodyMu.Unlock()
-		ctx, cancel := context.WithTimeout(context.Background(), srcStallReconnect)
-		n, err := readWithDeadline(ctx, body, chunk)
-		cancel()
+		if body == nil {
+			if s.reconnectFn == nil {
+				s.closeOnce.Do(func() { close(s.closed) })
+				return
+			}
+			nb, rerr := s.reconnectFn()
+			if rerr != nil {
+				if time.Since(lastLog) > reconnectLogEvery {
+					logger("[%s] reconnect to encoder failed: %v", s.label, rerr)
+					lastLog = time.Now()
+				}
+				select {
+				case <-time.After(srcReconnectBackoff):
+				case <-s.closed:
+					return
+				}
+				continue
+			}
+			logger("[%s] reconnected to encoder", s.label)
+			s.bodyMu.Lock()
+			s.body = nb
+			s.bodyMu.Unlock()
+			continue
+		}
+		n, err := readWithDeadline(body, chunk, srcStallReconnect)
 		if n > 0 {
-			lastRealBytes = time.Now()
+			lastReal = time.Now()
 			data := make([]byte, n)
 			copy(data, chunk[:n])
 			select {
@@ -1435,69 +1441,36 @@ func (s *stallTolerantReader) producer() {
 				continue
 			}
 		}
-		// n == 0 OR err != nil after partial read.
 		if err != nil {
-			logger("[%s] source idle/error (%v); reconnecting", s.label, err)
+			logger("[%s] encoder stream ended (%v); reconnecting", s.label, err)
 		}
 		body.Close()
-		if s.reconnectFn == nil {
-			s.closeOnce.Do(func() { close(s.closed) })
-			return
-		}
-		// Try to reconnect. While this loops, DVR keeps getting NULL packets.
-		// The outer-loop budget check handles the "reconnect succeeds repeatedly
-		// but yields no real bytes" case; this inner check handles "reconnect
-		// keeps failing outright".
-		var newBody io.ReadCloser
-		for {
-			select {
-			case <-s.closed:
-				return
-			default:
-			}
-			if time.Since(lastRealBytes) > maxUnhealthyDuration {
-				giveUp(fmt.Sprintf("no source bytes for %v during reconnect", maxUnhealthyDuration))
-				return
-			}
-			nb, rerr := s.reconnectFn()
-			if rerr == nil {
-				newBody = nb
-				break
-			}
-			logger("[%s] reconnect failed: %v", s.label, rerr)
-			select {
-			case <-time.After(srcReconnectBackoff):
-			case <-s.closed:
-				return
-			}
-		}
-		logger("[%s] reconnected", s.label)
 		s.bodyMu.Lock()
-		s.body = newBody
+		s.body = nil
 		s.bodyMu.Unlock()
 	}
 }
 
 func (s *stallTolerantReader) Read(p []byte) (int, error) {
-	timer := time.NewTimer(stallReadGap)
-	defer timer.Stop()
+	// Pre-first-chunk: nil channel disables the NULL-fill case, so Read blocks on chunks/closed only.
+	var stall <-chan time.Time
+	if s.hasFirstChunk.Load() {
+		t := time.NewTimer(stallReadGap)
+		defer t.Stop()
+		stall = t.C
+	}
 	select {
 	case <-s.closed:
 		return 0, io.EOF
 	case data := <-s.chunks:
+		s.hasFirstChunk.Store(true)
 		return copy(p, data), nil
-	case <-timer.C:
-		// Stalled — fill p with NULL packets to keep DVR's connection alive.
-		n := 0
-		for n+188 <= len(p) {
-			copy(p[n:n+188], nullTSPacket[:])
-			n += 188
-		}
-		if n == 0 {
-			// p < 188 bytes — return what fits
+	case <-stall:
+		if len(p) < 188 {
 			return copy(p, nullTSPacket[:]), nil
 		}
-		return n, nil
+		n := min(len(p)/188*188, len(nullFill))
+		return copy(p, nullFill[:n]), nil
 	}
 }
 
@@ -1512,23 +1485,11 @@ func (s *stallTolerantReader) Close() error {
 	return nil
 }
 
-// readWithDeadline performs r.Read(buf) with a context deadline. If the
-// deadline elapses, it returns (0, ctx.Err()) — the caller is expected to
-// close the underlying reader to release the leaked goroutine.
-func readWithDeadline(ctx context.Context, r io.Reader, buf []byte) (int, error) {
-	type result struct {
-		n   int
-		err error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		n, err := r.Read(buf)
-		ch <- result{n, err}
-	}()
-	select {
-	case res := <-ch:
-		return res.n, res.err
-	case <-ctx.Done():
-		return 0, ctx.Err()
-	}
+// readWithDeadline does r.Read with a timeout: on expiry the body is closed,
+// unblocking the blocked Read with an error. No goroutine leak, no buf race.
+func readWithDeadline(r io.ReadCloser, buf []byte, timeout time.Duration) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	defer context.AfterFunc(ctx, func() { r.Close() })()
+	return r.Read(buf)
 }


### PR DESCRIPTION
Essentially when you reboot your HDMI encoder (or any time bmitune.sh switches channels on a cold tuner), the encoder needs a few seconds to lock onto the new source. During that window it either stops sending TS data or closes the connection entirely. AH4C currently passes the encoder's stream straight through to Channels DVR, so when the encoder hiccups, Channels DVR sees the stream die and gives up on the tune. You end up having to start it again.

This patch puts a small buffering layer between the encoder and Channels DVR. AH4C reads from the encoder into a queue, and Channels DVR reads from the queue. If the encoder closes the connection or goes quiet for more than 5 seconds, AH4C reconnects to it behind the scenes and keeps trying until it works.

The part that makes this actually solve the problem: while AH4C is reconnecting (or the encoder is just paused), Channels DVR keeps getting MPEG-TS NULL packets, the standard "filler" packets every TS demuxer drops. From Channels DVR's side, bytes are still flowing, so it doesn't time out. As soon as the encoder is producing real data again, the NULLs stop and the real stream takes over seamlessly.

Normal warm tunes are unaffected, same speed as today. The recovery only kicks in when something actually breaks, and when it does, you don't have to do anything.

Built on: ghcr.io/mackid1993/ah4c:latest and tested on my Osprey stack and LinkPi ENC5-V2.

https://community.getchannels.com/t/androidhdmi-for-channels-ah4c-a-virtual-channel-tuner-using-hdmi-encoder-s-streaming-stick-s/38976/942?u=mackid1993

`main.go:1466-1487`
```
func (s *stallTolerantReader) Read(p []byte) (int, error) {
    timer := time.NewTimer(stallReadGap)  // 500ms
    defer timer.Stop()
    select {
    case <-s.closed:
        return 0, io.EOF
    case data := <-s.chunks:
        return copy(p, data), nil           // <-- real encoder bytes
    case <-timer.C:
        // Stalled — fill p with NULL packets to keep DVR's connection alive.
        n := 0
        for n+188 <= len(p) {
            copy(p[n:n+188], nullTSPacket[:])
            n += 188
        }
        if n == 0 {
            return copy(p, nullTSPacket[:]), nil
        }
        return n, nil                       // <-- NULL packets
    }
}
```
Just for full disclosure, this was built with Claude Opus 4.7. Essentially, it's a reliability fix. When we're getting video data, this doesn't kick in and it returns a stream instantly. When we're not getting video data, it sends null packets to fill in until video data starts flowing, and then we get regular video. This keeps Channels DVR from essentially dropping the stream prematurely. It really enhances reliability in my experience, especially for folks who reboot their encoders every couple of days or every night. I know with the LinkPi there's a setting to auto reboot, and it's sometimes recommended for certain use cases particularly when using the USB cam due to that freezing.