### PR TITLE
(fix) tuning failure causing by DirecTV Update

### DIFF
--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -38,9 +38,8 @@ adbConnect() {
       exit 2
     fi
     
-
     ((adbCounter++))
-    $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio 2>/dev/null | grep -E "pack: com.att.tv.openvideo.*gain: GAIN " >/dev/null && break; dumpsys media_session 2>/dev/null | grep "PlaybackState {state=3" >/dev/null && break; sleep 0.1; done'
+    
   done
 }
 
@@ -53,5 +52,6 @@ adbWake() {
 main() {
   adbConnect
   adbWake
+  $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio 2>/dev/null | grep -E "pack: com.att.tv.openvideo.*gain: GAIN " >/dev/null && break; dumpsys media_session 2>/dev/null | grep "PlaybackState {state=3" >/dev/null && break; sleep 0.1; done'
 }
 main

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #prebmitune.sh for osprey/dtvospreydeeplinks
-# 2025.09.26
+# 2026.06.25
 
 #Debug on if uncommented
 set -x
@@ -52,6 +52,7 @@ adbWake() {
 main() {
   adbConnect
   adbWake
+  $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio | grep -qE "pack: com.att.tv.openvideo.*gain: GAIN " && break; dumpsys media_session | grep -q "PlaybackState {state=3" && break; sleep 0.1; done'
 }
 
 main

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -39,7 +39,6 @@ adbConnect() {
     fi
     
     ((adbCounter++))
-    
   done
 }
 

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -40,6 +40,7 @@ adbConnect() {
     
 
     ((adbCounter++))
+    $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio 2>/dev/null | grep -E "pack: com.att.tv.openvideo.*gain: GAIN " >/dev/null && break; dumpsys media_session 2>/dev/null | grep "PlaybackState {state=3" >/dev/null && break; sleep 0.1; done'
   done
 }
 
@@ -52,7 +53,5 @@ adbWake() {
 main() {
   adbConnect
   adbWake
-  $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio 2>/dev/null | grep -E "pack: com.att.tv.openvideo.*gain: GAIN " >/dev/null && break; dumpsys media_session 2>/dev/null | grep "PlaybackState {state=3" >/dev/null && break; sleep 0.1; done'
 }
-
 main

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -52,7 +52,7 @@ adbWake() {
 main() {
   adbConnect
   adbWake
-  $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio | grep -qE "pack: com.att.tv.openvideo.*gain: GAIN " && break; dumpsys media_session | grep -q "PlaybackState {state=3" && break; sleep 0.1; done'
+  $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio 2>/dev/null | grep -E "pack: com.att.tv.openvideo.*gain: GAIN " >/dev/null && break; dumpsys media_session 2>/dev/null | grep "PlaybackState {state=3" >/dev/null && break; sleep 0.1; done'
 }
 
 main


### PR DESCRIPTION
Per my analysis with Claude:
On a cold wake the DirecTV app now runs a startup → re-auth → "Your TV" home sequence. Two things gate the tune during that window:

An entitlement check. The deeplink handler won't tune until the app confirms your account is active (subscribed, not paused). On a fresh wake that account state isn't loaded yet, so the tune is denied and postponed, and frequently dropped before it can be replayed.

To work around this prebmitune polls Android's audio-focus and MediaSession state and only proceeds to tune once the box reports it's actually playing using whichever reports first for a faster tune.

I am marking this as a draft as I would like a few days to test it before considering it rock solid. It's the closest I've come to solving this issue that many aren't facing yet as it seems this is a gradual rollout causing breakage.