### PR TITLE
(fix) Osprey Deeplinks Scrips keepwatching.sh PID's piling up

### DIFF
--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -58,8 +58,21 @@ matchEncoderURL() {
 #Tuning is based on channel name/ID values from dtvospreydeeplinks.m3u.
 tuneChannel() {
   $adbTarget shell "am start -a android.intent.action.VIEW -d 'https://deeplink.directvnow.com/tune/live/channel/$channelName/$channelID' com.att.tv.openvideo"
-  echo -e "#!/bin/bash\n\necho \"[\$(date)] Keep-alive started for $streamerIP (interval: $KEEP_WATCHING)\" > /proc/1/fd/1\nwhile true; do sleep $KEEP_WATCHING; echo \"[\$(date)] Keep-alive sent to $streamerIP\" > /proc/1/fd/1; $adbTarget shell input keyevent KEYCODE_MEDIA_PLAY; done" > ./$streamerNoPort/keep_watching.sh && chmod +x ./$streamerNoPort/keep_watching.sh
-  [[ $KEEP_WATCHING ]] && nohup ./$streamerNoPort/keep_watching.sh &
+  cat > ./$streamerNoPort/keep_watching.sh <<KWEOF
+#!/bin/bash
+trap 'echo "keep watching pid killed" > /proc/1/fd/1; exit 0' TERM INT
+echo "keep watching started interval $KEEP_WATCHING" > /proc/1/fd/1
+while true; do
+  sleep $KEEP_WATCHING
+  echo "keep watching event triggered" > /proc/1/fd/1
+  $adbTarget shell input keyevent KEYCODE_MEDIA_PLAY
+done
+KWEOF
+  chmod +x ./$streamerNoPort/keep_watching.sh
+  if [[ $KEEP_WATCHING ]]; then
+    setsid ./$streamerNoPort/keep_watching.sh >/dev/null 2>&1 &
+    echo $! > "$streamerNoPort/keep_watching_pid"
+  fi
 }
 main() {
   tuneChannel

--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # bmitune.sh for osprey/dtvospreydeeplinks
-# 2026.04.03
+# 2026.07.03
 #Debug on if uncommented
 set -x
 #Global

--- a/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # stopbmitune.sh for osprey/dtvospreydeeplinks
-# 2026.04.03
+# 2026.07.03
 #Debug on if uncommented
 set -x
 

--- a/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
@@ -11,17 +11,18 @@ adbTarget="adb -s $streamerIP"
 #Check if bmitune.sh is done running
 bmituneDone() {
   bmitunePID=$(<"$streamerNoPort/bmitune_pid")
-  keepWatchingPID=$(pgrep -f "$streamerNoPort/keep_watching.sh")
-  keepWatchingPPID=$(ps -o ppid= -p "$keepWatchingPID")
-  keepWatchingCPID=$(pgrep -P $keepWatchingPID)
 
   while ps -p $bmitunePID > /dev/null; do
     echo "Waiting for bmitune.sh to complete..."
     sleep 2
   done
 
-  [[ $KEEP_WATCHING ]] && pkill -P $keepWatchingPPID && kill $keepWatchingCPID
-  rm ./$streamerNoPort/keep_watching.sh
+  if [[ $KEEP_WATCHING && -f "$streamerNoPort/keep_watching_pid" ]]; then
+    keepWatchingPID=$(<"$streamerNoPort/keep_watching_pid")
+    kill -- -"$keepWatchingPID" 2>/dev/null
+    rm -f "./$streamerNoPort/keep_watching_pid"
+  fi
+  rm -f "./$streamerNoPort/keep_watching.sh"
 }
 
 #Device sleep


### PR DESCRIPTION
I noticed that the Deeplinks Scripts for the Osprey boxes had the PIDs piling up for `keep_watching.sh`. Must have been a mistake I made months ago when I implemented that feature. I'm marking this as a draft for now until I test it a little bit more over the weekend to ensure there are no more weird issues, but I have been able to confirm that tuning does create the scripts. This is obviously only an issue if someone is using that feature.

The script does run, and upon stopping the tune, the scripts are removed, and the PID is killed according `ps aux`. I decided to let Fable 5 have a crack at this just for some fun, so I hope this is okay. I will test this over the weekend and then mark it for review once I'm confident it seems to be working without any oddities.

running cat `keep_watching.sh` gives this output inside the container:
```
root@ah4c:/opt/192.168.200.21# cat keep_watching.sh
#!/bin/bash
trap 'echo "keep watching pid killed" > /proc/1/fd/1; exit 0' TERM INT
echo "keep watching started interval 1h" > /proc/1/fd/1
while true; do
  sleep 1h
  echo "keep watching event triggered" > /proc/1/fd/1
  adb -s 192.168.200.21:5555 shell input keyevent KEYCODE_MEDIA_PLAY
done
```

Thanks!!