### PR TITLE
(fix) Add heartbeat to Osprey Scripts for DTV Server side flag rollout

### DIFF
--- a/scripts/osprey/dtvosprey/bmitune.sh
+++ b/scripts/osprey/dtvosprey/bmitune.sh
@@ -10,7 +10,7 @@ streamerNoPort="${streamerIP%%:*}"
 adbTarget="timeout 15 adb -s $streamerIP"
 dtvPackage="com.att.tv.openvideo"
 heartbeatInterval=180
-heartbeatKeycode=211
+heartbeatKeycode=KEYCODE_ZENKAKU_HANKAKU
 
 mkdir -p "$streamerNoPort"
 echo $$ > "$streamerNoPort/bmitune_pid"
@@ -32,7 +32,7 @@ tuneChannel() {
 }
 
 #Resets the app's 5 minute UI inactivity timer, which otherwise restarts playback mid stream
-#Keycode 211 is inert on a US TV app, unlike media keycodes which draw an OSD
+#KEYCODE_ZENKAKU_HANKAKU is inert on a US TV app, unlike media keycodes which draw an OSD
 startHeartbeat() {
   if [[ -f "$streamerNoPort/heartbeat_pid" ]]; then
     kill -- -"$(<"$streamerNoPort/heartbeat_pid")" 2>/dev/null

--- a/scripts/osprey/dtvosprey/bmitune.sh
+++ b/scripts/osprey/dtvosprey/bmitune.sh
@@ -19,6 +19,7 @@ echo $$ > "$streamerNoPort/bmitune_pid"
 finish() {
   echo "bmitune.sh is exiting for $streamerIP with exit code $?"
 }
+
 trap finish EXIT
 
 #Tune by channel number; prebmitune.sh has already woken the box and gated on it being ready for input
@@ -55,4 +56,5 @@ main() {
   tuneChannel || exit 1
   startHeartbeat
 }
+
 main

--- a/scripts/osprey/dtvosprey/bmitune.sh
+++ b/scripts/osprey/dtvosprey/bmitune.sh
@@ -1,58 +1,58 @@
 #!/bin/bash
-#bmitune.sh for osprey/dtvosprey
-# 2025.09.10
-
+# bmitune.sh for osprey/dtvosprey
+# 2026.07.25
 #Debug on if uncommented
 set -x
-
 #Global
-channelID=\""$1\""
-specialID="$1"
+channelName=$(echo "$1" | awk -F~ '{print $1}')
 streamerIP="$2"
 streamerNoPort="${streamerIP%%:*}"
-adbTarget="adb -s $streamerIP"
-m3uName="${STREAMER_APP#*/*/}.m3u"
+adbTarget="timeout 15 adb -s $streamerIP"
+dtvPackage="com.att.tv.openvideo"
+heartbeatInterval=180
+heartbeatKeycode=211
 
+mkdir -p "$streamerNoPort"
+echo $$ > "$streamerNoPort/bmitune_pid"
 
 #Trap end of script run
 finish() {
   echo "bmitune.sh is exiting for $streamerIP with exit code $?"
 }
-
 trap finish EXIT
 
-#Set encoderURL based on the value of streamerIP
-matchEncoderURL() {
-
-  case "$streamerIP" in
-    "$TUNER1_IP")
-      encoderURL=$ENCODER1_URL
-      ;;
-    "$TUNER2_IP")
-      encoderURL=$ENCODER2_URL
-      ;;
-    "$TUNER3_IP")
-      encoderURL=$ENCODER3_URL
-      ;;
-    "$TUNER4_IP")
-      encoderURL=$ENCODER4_URL
-      ;;
-    *)
-      exit 1
-      ;;
-  esac
-}
-
-#Tuning is based on channel name values from $m3uName.
+#Tune by channel number; prebmitune.sh has already woken the box and gated on it being ready for input
 tuneChannel() {
-  
-  $adbTarget shell input text $channelID; 
+  if [[ -z "$channelName" ]]; then
+    echo "Tune: ERROR - empty channel name from m3u"
+    return 1
+  fi
+
+  $adbTarget shell input text "\"$channelName\""
 }
 
+#Resets the app's 5 minute UI inactivity timer, which otherwise restarts playback mid stream
+#Keycode 211 is inert on a US TV app, unlike media keycodes which draw an OSD
+startHeartbeat() {
+  if [[ -f "$streamerNoPort/heartbeat_pid" ]]; then
+    kill -- -"$(<"$streamerNoPort/heartbeat_pid")" 2>/dev/null
+  fi
+  cat > "./$streamerNoPort/heartbeat.sh" <<HBEOF
+#!/bin/bash
+trap 'echo "heartbeat pid killed" > /proc/1/fd/1; exit 0' TERM INT
+echo "heartbeat started for $streamerIP -- keyevent $heartbeatKeycode every ${heartbeatInterval}s" > /proc/1/fd/1
+while true; do
+  sleep $heartbeatInterval
+  $adbTarget shell input keyevent $heartbeatKeycode
+done
+HBEOF
+  chmod +x "./$streamerNoPort/heartbeat.sh"
+  setsid "./$streamerNoPort/heartbeat.sh" >/dev/null 2>&1 &
+  echo $! > "$streamerNoPort/heartbeat_pid"
+}
 
 main() {
-  matchEncoderURL
-  tuneChannel
+  tuneChannel || exit 1
+  startHeartbeat
 }
-
 main

--- a/scripts/osprey/dtvosprey/bmitune.sh
+++ b/scripts/osprey/dtvosprey/bmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # bmitune.sh for osprey/dtvosprey
-# 2026.07.25
+# 2026.07.29
 #Debug on if uncommented
 set -x
 #Global

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #prebmitune.sh for osprey/dtvosprey
-# 2026.07.25
+# 2026.07.29
 #Debug on if uncommented
 set -x
 

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -46,13 +46,15 @@ adbWake() {
   touch "$streamerNoPort/adbAppRunning"
 }
 
-#Block until the app holds audio focus or reports playing, otherwise the tune gets dropped
+#Block until the app is playing AND owns the focused window, otherwise input text goes nowhere
+#mCurrentFocus is the only signal that says a keystroke will land; mFocusedApp stays set while asleep
 readinessGate() {
   $adbTarget shell "
     end=\$((SECONDS+10))
     while [ \$SECONDS -lt \$end ]; do
-      dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0
-      dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0
+      if dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' || dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)'; then
+        dumpsys window 2>/dev/null | grep -q 'mCurrentFocus=Window.*$dtvPackage' && exit 0
+      fi
     done
     exit 1"
 

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 #prebmitune.sh for osprey/dtvosprey
-# 2025.09.10
-
+# 2026.07.25
 #Debug on if uncommented
-set -x
+#set -x
 
 streamerIP="$1"
 streamerNoPort="${streamerIP%%:*}"
-adbTarget="adb -s $streamerIP"
+adbTarget="timeout 15 adb -s $streamerIP"
+dtvPackage="com.att.tv.openvideo"
 
-mkdir -p $streamerNoPort
+mkdir -p "$streamerNoPort"
 
 #Trap end of script run
 finish() {
@@ -19,12 +19,11 @@ finish() {
 trap finish EXIT
 
 adbConnect() {
-  adb connect $streamerIP
-
   local -i adbMaxRetries=3
   local -i adbCounter=0
 
   while true; do
+    adb connect "$streamerIP"
     $adbTarget shell input keyevent KEYCODE_WAKEUP
     local adbEventSuccess=$?
 
@@ -33,27 +32,36 @@ adbConnect() {
     fi
 
     if (($adbCounter > $adbMaxRetries)); then
-      touch $streamerNoPort/adbCommunicationFail
+      touch "$streamerNoPort/adbCommunicationFail"
       echo "Communication with $streamerIP failed after $adbMaxRetries retries"
       exit 2
     fi
-    
-
     ((adbCounter++))
   done
 }
 
 adbWake() {
+  $adbTarget shell input keyevent KEYCODE_WAKEUP
+  echo "Waking $streamerIP"
+  touch "$streamerNoPort/adbAppRunning"
+}
 
-    $adbTarget shell input keyevent KEYCODE_WAKEUP; sleep 2;
-    echo "Waking $streamerIP"
-    touch $streamerNoPort/adbAppRunning
-
+#Block until the app holds audio focus or reports playing, otherwise the channel digits get dropped
+#The host side timeout is the only time authority so the verdict never depends on adb propagating remote exit codes
+readyGate() {
+  timeout 12 adb -s "$streamerIP" shell "while true; do dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0; dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0; sleep 0.2; done"
 }
 
 main() {
   adbConnect
   adbWake
+  if readyGate; then
+    echo "Readiness gate: $streamerIP is live and hot"
+  else
+    touch "$streamerNoPort/adbCommunicationFail"
+    echo "Readiness gate timed out for $streamerIP -- failing tune so ah4c can try the next tuner"
+    exit 2
+  fi
 }
 
 main

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -2,7 +2,7 @@
 #prebmitune.sh for osprey/dtvosprey
 # 2026.07.25
 #Debug on if uncommented
-#set -x
+set -x
 
 streamerIP="$1"
 streamerNoPort="${streamerIP%%:*}"

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -47,21 +47,28 @@ adbWake() {
 }
 
 #Block until the app holds audio focus or reports playing, otherwise the channel digits get dropped
-#The host side timeout is the only time authority so the verdict never depends on adb propagating remote exit codes
 readyGate() {
-  timeout 12 adb -s "$streamerIP" shell "while true; do dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0; dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0; done"
+  $adbTarget shell "
+    end=\$((SECONDS+10))
+    while [ \$SECONDS -lt \$end ]; do
+      dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0
+      dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0
+    done
+    exit 1"
+
+  if [[ $? -ne 0 ]]; then
+    touch "$streamerNoPort/adbCommunicationFail"
+    echo "Readiness gate timed out for $streamerIP -- failing tune so ah4c can try the next tuner"
+    exit 2
+  fi
+
+  echo "Readiness gate: $streamerIP is live and hot"
 }
 
 main() {
   adbConnect
   adbWake
-  if readyGate; then
-    echo "Readiness gate: $streamerIP is live and hot"
-  else
-    touch "$streamerNoPort/adbCommunicationFail"
-    echo "Readiness gate timed out for $streamerIP -- failing tune so ah4c can try the next tuner"
-    exit 2
-  fi
+  readyGate
 }
 
 main

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -52,7 +52,7 @@ readinessGate() {
   $adbTarget shell "
     end=\$((SECONDS+10))
     while [ \$SECONDS -lt \$end ]; do
-      if dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' || dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)'; then
+      if dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' || dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=3'; then
         dumpsys window 2>/dev/null | grep -q 'mCurrentFocus=Window.*$dtvPackage' && exit 0
       fi
     done

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -49,7 +49,7 @@ adbWake() {
 #Block until the app holds audio focus or reports playing, otherwise the channel digits get dropped
 #The host side timeout is the only time authority so the verdict never depends on adb propagating remote exit codes
 readyGate() {
-  timeout 12 adb -s "$streamerIP" shell "while true; do dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0; dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0; sleep 0.2; done"
+  timeout 12 adb -s "$streamerIP" shell "while true; do dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0; dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0; done"
 }
 
 main() {

--- a/scripts/osprey/dtvosprey/prebmitune.sh
+++ b/scripts/osprey/dtvosprey/prebmitune.sh
@@ -46,8 +46,8 @@ adbWake() {
   touch "$streamerNoPort/adbAppRunning"
 }
 
-#Block until the app holds audio focus or reports playing, otherwise the channel digits get dropped
-readyGate() {
+#Block until the app holds audio focus or reports playing, otherwise the tune gets dropped
+readinessGate() {
   $adbTarget shell "
     end=\$((SECONDS+10))
     while [ \$SECONDS -lt \$end ]; do
@@ -68,7 +68,7 @@ readyGate() {
 main() {
   adbConnect
   adbWake
-  readyGate
+  readinessGate
 }
 
 main

--- a/scripts/osprey/dtvosprey/stopbmitune.sh
+++ b/scripts/osprey/dtvosprey/stopbmitune.sh
@@ -43,4 +43,5 @@ main() {
   bmituneDone
   adbSleep
 }
+
 main

--- a/scripts/osprey/dtvosprey/stopbmitune.sh
+++ b/scripts/osprey/dtvosprey/stopbmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # stopbmitune.sh for osprey/dtvosprey
-# 2026.07.25
+# 2026.07.29
 
 #Debug on if uncommented
 set -x

--- a/scripts/osprey/dtvosprey/stopbmitune.sh
+++ b/scripts/osprey/dtvosprey/stopbmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-#stopbmitune.sh for osprey/dtvosprey
-# 2025.09.10
+# stopbmitune.sh for osprey/dtvosprey
+# 2026.07.25
 
 #Debug on if uncommented
 set -x
@@ -9,18 +9,38 @@ streamerIP="$1"
 streamerNoPort="${streamerIP%%:*}"
 adbTarget="adb -s $streamerIP"
 
+#Check if bmitune.sh is done running, then kill the heartbeat before the device is slept
+bmituneDone() {
+  if [[ -f "$streamerNoPort/bmitune_pid" ]]; then
+    bmitunePID=$(<"$streamerNoPort/bmitune_pid")
+
+    #Bounded: a recycled PID could otherwise spin this forever and leak the tuner
+    local -i waited=0
+    while ps -p "$bmitunePID" > /dev/null && (( waited++ < 15 )); do
+      echo "Waiting for bmitune.sh to complete..."
+      sleep 2
+    done
+  fi
+
+  if [[ -f "$streamerNoPort/heartbeat_pid" ]]; then
+    heartbeatPID=$(<"$streamerNoPort/heartbeat_pid")
+    kill -- -"$heartbeatPID" 2>/dev/null
+    rm -f "./$streamerNoPort/heartbeat_pid"
+  fi
+  rm -f "./$streamerNoPort/heartbeat.sh"
+}
+
 #Device sleep
 adbSleep() {
   sleep="input keyevent KEYCODE_SLEEP"
-
   $adbTarget shell $sleep
   echo "Sleep initiated for $streamerIP"
-  date +%s > $streamerNoPort/stream_stopped
+  date +%s > "$streamerNoPort/stream_stopped"
   echo "$streamerNoPort/stream_stopped written with epoch stop time"
 }
 
 main() {
+  bmituneDone
   adbSleep
 }
-
 main

--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -21,46 +21,14 @@ echo $$ > "$streamerNoPort/bmitune_pid"
 finish() {
   echo "bmitune.sh is exiting for $streamerIP with exit code $?"
 }
+
 trap finish EXIT
-#Set encoderURL based on the value of streamerIP
-matchEncoderURL() {
-  case "$streamerIP" in
-    "$TUNER1_IP")
-        encoderURL=$ENCODER1_URL
-        ;;
-    "$TUNER2_IP")
-        encoderURL=$ENCODER2_URL
-        ;;
-    "$TUNER3_IP")
-        encoderURL=$ENCODER3_URL
-        ;;
-    "$TUNER4_IP")
-        encoderURL=$ENCODER4_URL
-        ;;
-    "$TUNER5_IP")
-        encoderURL=$ENCODER5_URL
-        ;;
-    "$TUNER6_IP")
-        encoderURL=$ENCODER6_URL
-        ;;
-    "$TUNER7_IP")
-        encoderURL=$ENCODER7_URL
-        ;;
-    "$TUNER8_IP")
-        encoderURL=$ENCODER8_URL
-        ;;
-    "$TUNER9_IP")
-        encoderURL=$ENCODER9_URL
-        ;;
-    *)
-        exit 1
-        ;;
-  esac
-}
+
 #Tuning is based on channel name/ID values from dtvospreydeeplinks.m3u.
 tuneChannel() {
   $adbTarget shell "am start -a android.intent.action.VIEW -d 'https://deeplink.directvnow.com/tune/live/channel/$channelName/$channelID' com.att.tv.openvideo"
 }
+
 #Resets the app's 5 minute UI inactivity timer, which otherwise restarts playback mid stream
 #KEYCODE_ZENKAKU_HANKAKU is inert on a US TV app, unlike media keycodes which draw an OSD
 startHeartbeat() {
@@ -80,8 +48,10 @@ HBEOF
   setsid ./$streamerNoPort/heartbeat.sh >/dev/null 2>&1 &
   echo $! > "$streamerNoPort/heartbeat_pid"
 }
+
 main() {
   tuneChannel
   startHeartbeat
 }
+
 main

--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -6,11 +6,9 @@ set -x
 #Global
 channelID=$(echo $1 | awk -F~ '{print $2}')
 channelName=$(echo $1 | awk -F~ '{print $1}')
-specialID="$channelName"
 streamerIP="$2"
 streamerNoPort="${streamerIP%%:*}"
 adbTarget="adb -s $streamerIP"
-[[ $SPEED_MODE == "" ]] && speedMode="true" || speedMode="$SPEED_MODE"
 heartbeatInterval=180
 heartbeatKeycode=KEYCODE_ZENKAKU_HANKAKU
 

--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -12,7 +12,7 @@ streamerNoPort="${streamerIP%%:*}"
 adbTarget="adb -s $streamerIP"
 [[ $SPEED_MODE == "" ]] && speedMode="true" || speedMode="$SPEED_MODE"
 heartbeatInterval=180
-heartbeatKeycode=211
+heartbeatKeycode=KEYCODE_ZENKAKU_HANKAKU
 
 mkdir -p $streamerNoPort
 echo $$ > "$streamerNoPort/bmitune_pid"
@@ -62,7 +62,7 @@ tuneChannel() {
   $adbTarget shell "am start -a android.intent.action.VIEW -d 'https://deeplink.directvnow.com/tune/live/channel/$channelName/$channelID' com.att.tv.openvideo"
 }
 #Resets the app's 5 minute UI inactivity timer, which otherwise restarts playback mid stream
-#Keycode 211 is inert on a US TV app, unlike media keycodes which draw an OSD
+#KEYCODE_ZENKAKU_HANKAKU is inert on a US TV app, unlike media keycodes which draw an OSD
 startHeartbeat() {
   if [[ -f "$streamerNoPort/heartbeat_pid" ]]; then
     kill -- -"$(<"$streamerNoPort/heartbeat_pid")" 2>/dev/null

--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # bmitune.sh for osprey/dtvospreydeeplinks
-# 2026.07.25
+# 2026.07.29
 #Debug on if uncommented
 set -x
 #Global

--- a/scripts/osprey/dtvospreydeeplinks/bmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/bmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # bmitune.sh for osprey/dtvospreydeeplinks
-# 2026.07.03
+# 2026.07.25
 #Debug on if uncommented
 set -x
 #Global
@@ -11,6 +11,8 @@ streamerIP="$2"
 streamerNoPort="${streamerIP%%:*}"
 adbTarget="adb -s $streamerIP"
 [[ $SPEED_MODE == "" ]] && speedMode="true" || speedMode="$SPEED_MODE"
+heartbeatInterval=180
+heartbeatKeycode=211
 
 mkdir -p $streamerNoPort
 echo $$ > "$streamerNoPort/bmitune_pid"
@@ -58,23 +60,28 @@ matchEncoderURL() {
 #Tuning is based on channel name/ID values from dtvospreydeeplinks.m3u.
 tuneChannel() {
   $adbTarget shell "am start -a android.intent.action.VIEW -d 'https://deeplink.directvnow.com/tune/live/channel/$channelName/$channelID' com.att.tv.openvideo"
-  cat > ./$streamerNoPort/keep_watching.sh <<KWEOF
-#!/bin/bash
-trap 'echo "keep watching pid killed" > /proc/1/fd/1; exit 0' TERM INT
-echo "keep watching started interval $KEEP_WATCHING" > /proc/1/fd/1
-while true; do
-  sleep $KEEP_WATCHING
-  echo "keep watching event triggered" > /proc/1/fd/1
-  $adbTarget shell input keyevent KEYCODE_MEDIA_PLAY
-done
-KWEOF
-  chmod +x ./$streamerNoPort/keep_watching.sh
-  if [[ $KEEP_WATCHING ]]; then
-    setsid ./$streamerNoPort/keep_watching.sh >/dev/null 2>&1 &
-    echo $! > "$streamerNoPort/keep_watching_pid"
+}
+#Resets the app's 5 minute UI inactivity timer, which otherwise restarts playback mid stream
+#Keycode 211 is inert on a US TV app, unlike media keycodes which draw an OSD
+startHeartbeat() {
+  if [[ -f "$streamerNoPort/heartbeat_pid" ]]; then
+    kill -- -"$(<"$streamerNoPort/heartbeat_pid")" 2>/dev/null
   fi
+  cat > ./$streamerNoPort/heartbeat.sh <<HBEOF
+#!/bin/bash
+trap 'echo "heartbeat pid killed" > /proc/1/fd/1; exit 0' TERM INT
+echo "heartbeat started for $streamerIP -- keyevent $heartbeatKeycode every ${heartbeatInterval}s" > /proc/1/fd/1
+while true; do
+  sleep $heartbeatInterval
+  $adbTarget shell input keyevent $heartbeatKeycode
+done
+HBEOF
+  chmod +x ./$streamerNoPort/heartbeat.sh
+  setsid ./$streamerNoPort/heartbeat.sh >/dev/null 2>&1 &
+  echo $! > "$streamerNoPort/heartbeat_pid"
 }
 main() {
   tuneChannel
+  startHeartbeat
 }
 main

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #prebmitune.sh for osprey/dtvospreydeeplinks
-# 2026.06.25
+# 2026.07.25
 
 #Debug on if uncommented
 set -x
@@ -37,7 +37,7 @@ adbConnect() {
       echo "Communication with $streamerIP failed after $adbMaxRetries retries"
       exit 2
     fi
-    
+
     ((adbCounter++))
   done
 }
@@ -48,9 +48,28 @@ adbWake() {
   touch $streamerNoPort/adbAppRunning
 }
 
+#Block until audio focus or playback state says the box is hot, then fail the tune if it never is
+readinessGate() {
+  $adbTarget shell '
+    end=$((SECONDS+10))
+    while [ $SECONDS -lt $end ]; do
+      dumpsys audio 2>/dev/null | grep -qE "pack: com.att.tv.openvideo.*gain: GAIN " && exit 0
+      dumpsys media_session 2>/dev/null | grep -qE "PlaybackState \{state=(3|8)" && exit 0
+    done
+    exit 1'
+
+  if [[ $? -ne 0 ]]; then
+    touch "$streamerNoPort/adbCommunicationFail"
+    echo "Readiness gate timed out for $streamerIP -- failing tune so ah4c can try the next tuner"
+    exit 2
+  fi
+
+  echo "Readiness gate: $streamerIP is live and hot"
+}
+
 main() {
   adbConnect
   adbWake
-  $adbTarget shell 'for i in $(seq 1 80); do dumpsys audio 2>/dev/null | grep -E "pack: com.att.tv.openvideo.*gain: GAIN " >/dev/null && break; dumpsys media_session 2>/dev/null | grep "PlaybackState {state=3" >/dev/null && break; sleep 0.1; done'
+  readinessGate
 }
 main

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -73,4 +73,5 @@ main() {
   adbWake
   readinessGate
 }
+
 main

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -55,7 +55,7 @@ readinessGate() {
     end=\$((SECONDS+10))
     while [ \$SECONDS -lt \$end ]; do
       dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0
-      dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0
+      dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=3' && exit 0
     done
     exit 1"
 

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #prebmitune.sh for osprey/dtvospreydeeplinks
-# 2026.07.25
+# 2026.07.29
 
 #Debug on if uncommented
 set -x

--- a/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/prebmitune.sh
@@ -7,7 +7,8 @@ set -x
 
 streamerIP="$1"
 streamerNoPort="${streamerIP%%:*}"
-adbTarget="adb -s $streamerIP"
+adbTarget="timeout 15 adb -s $streamerIP"
+dtvPackage="com.att.tv.openvideo"
 
 mkdir -p $streamerNoPort
 
@@ -48,15 +49,15 @@ adbWake() {
   touch $streamerNoPort/adbAppRunning
 }
 
-#Block until audio focus or playback state says the box is hot, then fail the tune if it never is
+#Block until the app holds audio focus or reports playing, otherwise the tune gets dropped
 readinessGate() {
-  $adbTarget shell '
-    end=$((SECONDS+10))
-    while [ $SECONDS -lt $end ]; do
-      dumpsys audio 2>/dev/null | grep -qE "pack: com.att.tv.openvideo.*gain: GAIN " && exit 0
-      dumpsys media_session 2>/dev/null | grep -qE "PlaybackState \{state=(3|8)" && exit 0
+  $adbTarget shell "
+    end=\$((SECONDS+10))
+    while [ \$SECONDS -lt \$end ]; do
+      dumpsys audio 2>/dev/null | grep -qE 'pack: $dtvPackage.*gain: GAIN ' && exit 0
+      dumpsys media_session 2>/dev/null | grep -qE 'PlaybackState \{state=(3|8)' && exit 0
     done
-    exit 1'
+    exit 1"
 
   if [[ $? -ne 0 ]]; then
     touch "$streamerNoPort/adbCommunicationFail"

--- a/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # stopbmitune.sh for osprey/dtvospreydeeplinks
-# 2026.07.25
+# 2026.07.29
 #Debug on if uncommented
 set -x
 

--- a/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
@@ -38,4 +38,5 @@ main() {
   bmituneDone
   adbSleep
 }
+
 main

--- a/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
+++ b/scripts/osprey/dtvospreydeeplinks/stopbmitune.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # stopbmitune.sh for osprey/dtvospreydeeplinks
-# 2026.07.03
+# 2026.07.25
 #Debug on if uncommented
 set -x
 
@@ -8,7 +8,7 @@ streamerIP="$1"
 streamerNoPort="${streamerIP%%:*}"
 adbTarget="adb -s $streamerIP"
 
-#Check if bmitune.sh is done running
+#Check if bmitune.sh is done running, then kill the heartbeat before the device is slept
 bmituneDone() {
   bmitunePID=$(<"$streamerNoPort/bmitune_pid")
 
@@ -17,12 +17,12 @@ bmituneDone() {
     sleep 2
   done
 
-  if [[ $KEEP_WATCHING && -f "$streamerNoPort/keep_watching_pid" ]]; then
-    keepWatchingPID=$(<"$streamerNoPort/keep_watching_pid")
-    kill -- -"$keepWatchingPID" 2>/dev/null
-    rm -f "./$streamerNoPort/keep_watching_pid"
+  if [[ -f "$streamerNoPort/heartbeat_pid" ]]; then
+    heartbeatPID=$(<"$streamerNoPort/heartbeat_pid")
+    kill -- -"$heartbeatPID" 2>/dev/null
+    rm -f "./$streamerNoPort/heartbeat_pid"
   fi
-  rm -f "./$streamerNoPort/keep_watching.sh"
+  rm -f "./$streamerNoPort/heartbeat.sh"
 }
 
 #Device sleep


### PR DESCRIPTION
This was authored with the assistance of Claude Opus 5 and culminates a month of debugging my fleet of 10 Osprey boxes. The scripts refine the previous readiness gate add a 3 minute heartbeat to each script needed to keep Ospreys that receive a series of server side flags from reloading their stream after 5 minutes. I also refactored the channel number scripts for better reliability in my testing. I have a detailed explanation on the Channels Forums starting here: https://community.getchannels.com/t/directv-osprey-gemini-boxes/45830/167?u=mackid1993

and slightly more info here: https://community.getchannels.com/t/directv-osprey-gemini-boxes/45830/170?u=mackid1993

I would recommend holding these until more people start complaining about this issue although the channel # tuning scripts might be useful now because I feel like they are a little bit more reliable than the old ones. Therefore I am going to mark this as a draft.
