### PR TITLE
Build ah4c from the checkout being built rather than re-cloning it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN npm install
 
 # Build ah4c application
 WORKDIR /go/src/github.com/sullrich
-RUN git clone https://github.com/sullrich/ah4c . \
-    && go build -o /opt/ah4c
+COPY . .
+RUN go build -o /opt/ah4c
 
 # Second Stage: Create the Runtime Environment
 FROM debian:bookworm-slim AS runner


### PR DESCRIPTION
The image is currently assembled from two different revisions of the project, which is why the Closed Captions page arrives broken.

The web pages are copied from the build context:

```dockerfile
COPY html/* /opt/html/
```

but the binary is built from a fresh clone of this repository's **default branch**:

```dockerfile
WORKDIR /go/src/github.com/sullrich
RUN git clone https://github.com/sullrich/ah4c . \
    && go build -o /opt/ah4c
```

There is no `git checkout`, so that clone lands on `main`, and `main` has no `captions.go`. Building `beta` therefore ships `html/captions.html` alongside a binary with no `/captions` route, no handler and no caption engine behind it. The page is in the image and there is nothing serving it.

Confirmed against the two branches:

| | `captions.go` | `html/captions.html` |
| --- | --- | --- |
| `main` (cloned) | absent | absent |
| `beta` (build context) | present | present |

This replaces the clone with the checkout already being built:

```dockerfile
WORKDIR /go/src/github.com/sullrich
COPY . .
RUN go build -o /opt/ah4c
```

Two lines. The binary and the pages beside it are now always the same revision, so they cannot come apart again on any branch, and the build no longer needs to reach GitHub for source it already has.