### PR TITLE
Stamp every build with a CalVer version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN npm install
 # Build ah4c application
 WORKDIR /go/src/github.com/sullrich
 RUN git clone --branch main --single-branch https://github.com/sullrich/ah4c . \
+    && sh bump-version.sh \
     && go build -o /opt/ah4c
 
 # Second Stage: Create the Runtime Environment

--- a/bump-version.sh
+++ b/bump-version.sh
@@ -10,7 +10,7 @@
 # the same minute, or a clock that went backwards — the last field is
 # incremented instead, so the version never repeats and never goes down.
 set -eu
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")"
 now="v$(date -u +%Y.%m.%d.%H%M)"
 cur="$(cat VERSION 2>/dev/null || echo)"
 if [ -n "$cur" ] && [ "$now" != "$(printf '%s\n%s\n' "$now" "$cur" | sort | tail -1)" ]; then

--- a/main.go
+++ b/main.go
@@ -1295,7 +1295,7 @@ func loadenv() {
 
 // Almighty main function
 func main() {
-	logger("[START] ah4c is starting")
+	logger("[START] ah4c %s is starting", buildVersion())
 	loadenv()
 	loadCaptionConfig()
 	warnIfNotPersistent()

--- a/version.go
+++ b/version.go
@@ -9,7 +9,7 @@ import (
 //
 // Embedding means a binary always knows its own version however it was built —
 // go build on a laptop, the Dockerfile, or the workflow — with nothing to
-// remember to pass. scripts/bump-version.sh writes it, in UTC, and the build
+// remember to pass. bump-version.sh writes it, in UTC, and the build
 // runs that before compiling.
 //
 //go:embed VERSION


### PR DESCRIPTION
> Written by David's agent (@mackid1993). David asked me to resolve the conflicts here and to justify every line, so the reasoning is visible rather than assumed.

## Why this conflicted

When this PR was opened, none of the CalVer work existed upstream. It does now. Commit 879c966, "Stamped every build with a CalVer version and put it in the page bar", reached `main` by way of #20 into `beta` and then #23, and it carries almost everything this PR originally proposed:

| Piece | On `main` today |
|---|---|
| `VERSION` | yes |
| `version.go`, the `go:embed` and `buildVersion()` | yes, byte identical to this branch |
| `bump-version.sh` | yes, byte identical to this branch (blob `7b8c729`) |
| `GET /api/version` | yes |
| the stamp in the page bar, and its footer fallback under 760px | yes |

So all three conflicts (`Dockerfile`, `VERSION`, `main.go`) were this branch re-adding what already exists. It has been rebuilt on top of current `main` and now carries only what is genuinely missing. `VERSION` and the 143 line caption and pyatv route block in `main.go` resolved to "take upstream unchanged" and drop out of the diff entirely.

## What is actually missing

**Nothing calls the script.** Grepping `main` for `bump-version` returns exactly two hits: the script's own header comment, and a line in `version.go` claiming the build runs it. Neither is a caller.

The image clones the repo and compiles the committed `VERSION` verbatim, so every container published from `main` reports `v2026.08.17.1611`. That is when the file was written, not when the image was built.

The stamp renders in the corner of every page and it is wrong. That is worse than not having one, because a number that never changes still reads as an answer when someone asks which build a user is on.

## The four lines, and why each one

### 1. `Dockerfile`, line 25

```diff
 RUN git clone --branch main --single-branch https://github.com/sullrich/ah4c . \
+    && sh bump-version.sh \
     && go build -o /opt/ah4c
```

This is the fix. Everything else is bookkeeping around it.

Placed after the clone, because the script does not exist until the repo is there, and before `go build`, because `go:embed` reads `VERSION` at compile time. Line 24 is untouched, so the `--branch main --single-branch` form is preserved exactly.

`Dockerfile-pyatv` is deliberately not touched. It is no longer a build path: the main `Dockerfile` installs pyatv itself and `docker-start.sh` selects `atvremote` at runtime on `PYATV=true`, and nothing in the tree references `Dockerfile-pyatv` any more.

### 2. `scripts/bump-version.sh` moved to `bump-version.sh`

`scripts/` is for tuner scripts. Every other file in it lives under `<device>/<provider>/` and is reached by a tune. `bump-version.sh` is the only file at that directory's top level and the only one no tune ever calls. The root already holds `adbpackages.sh`, `docker-start.sh`, `docker-start-pyatv.sh` and `start.sh`, which is the same kind of thing.

This is the one part of the PR that is not purely additive, since it relocates a file you have already merged. Happy to drop it if you would rather keep the path stable. The Dockerfile line works either way.

### 3. `bump-version.sh`, line 13

```diff
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")"
```

Required by the move, and a trap worth spelling out. The `/..` existed to climb out of `scripts/`. From the root it climbs out of the repo. In the image that lands on `/go/src/github.com`, which exists, so nothing fails:

- `cat VERSION` returns nothing and the `|| echo` swallows the error
- the new stamp is written to a `VERSION` beside the checkout
- the repo's own `VERSION` is never touched
- `go build` embeds the old value
- the script prints the correct new version and exits 0

The build log looks right and the binary is stamped wrong. Replaying the builder stage at `/go/src/github.com/sullrich` under `dash` on a Debian userland, both ways:

| script's `cd` | `VERSION` in repo | `go build` | stamp compiled into binary |
|---|---|---|---|
| `cd "$(dirname "$0")"` | `v2026.08.23.1755` | exit 0 | `v2026.08.23.1755` |
| `cd "$(dirname "$0")/.."` | `v2026.08.17.1611` | exit 0 | `v2026.08.17.1611` |

### 4. `version.go` line 12, and `main.go` line 1298

`version.go`'s comment gave the old path. It was also the only reference to that path anywhere in the tree, so the move needs no other edit. The same comment already claims "the build runs that before compiling", which this PR makes true.

`main.go` names the version in the startup log:

```diff
-	logger("[START] ah4c is starting")
+	logger("[START] ah4c %s is starting", buildVersion())
```

`logger` is already variadic and printf style, so nothing else changes. **This line is optional.** `/api/version` and the page stamp already answer the question. It earns its place only for a container too unwell to serve a page, where the first line of output still identifies the build. Say the word and it comes out.

## Verified

- Cross compiled for `linux/amd64`, clean
- `bump-version.sh` uses UTC and not local time: 17:38 UTC against 13:38 local on the machine that ran it
- Two runs inside the same minute give `.1738` then `.1739`, so the version never repeats and never goes backwards
- Built the binary, ran it, and confirmed the startup log, `GET /api/version`, and the stamp rendered in the page bar all report the same fresh value
- Rebuilt and restarted, and confirmed the served stamp moved with the build rather than tracking a clock
- Confirmed the footer fallback still takes over below 760px

Docker itself was not run, as there is no Docker on the machine this was prepared on. The builder stage's shell commands and the `go:embed` behavior were replayed directly, which is where the change lives, but the image has not been built end to end. Worth a CI build before merging on that basis.

## Not included

No UI change. The stamp, its CSS, and the 760px footer fallback are already on `main` and are untouched here.

`VERSION` is left at whatever is committed. The build overwrites it, so the value in the tree only ever seeds a local `go build`.
