### PR TITLE
Minor fix for top bar navigation when embedded in an iFrame

### DIFF
--- a/html/logs.html
+++ b/html/logs.html
@@ -36,7 +36,7 @@
 		</div>
 	</div>
 	<script>
-		if (window.self !== window.top || new URLSearchParams(window.location.search).has('notime')) {
+		if (new URLSearchParams(window.location.search).has('notime')) {
 			document.getElementById('time-header').classList.add('hidden');
 		}
 	</script>

--- a/html/status.html
+++ b/html/status.html
@@ -123,7 +123,7 @@
     </div>
 
     <script>
-        if (window.self !== window.top) document.getElementById('pageNav').classList.add('hidden');
+        if (new URLSearchParams(window.location.search).has('embedded')) document.getElementById('pageNav').classList.add('hidden');
     </script>
     <script>
         var modalIndex = null;

--- a/html/status_and_logs.html
+++ b/html/status_and_logs.html
@@ -37,14 +37,14 @@
 		<div class="shell-body">
 			<div class="split" id="split">
 				<div class="split-pane split-left">
-					<iframe src="/status"></iframe>
+					<iframe src="/status?embedded=1"></iframe>
 				</div>
 				<div class="split-pane split-right">
 					<button class="split-handle" onclick="toggleLogs()" title="Expand logs">
 						<svg id="triUp" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 15 12 9 18 15"/></svg>
 						<svg id="triDown" class="hidden" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
 					</button>
-					<iframe src="/logs?notime"></iframe>
+					<iframe src="/logs?notime&embedded=1"></iframe>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
With the new WebUI, when embedded in an iFrame (like with Organizr), top bar navigation would disappear for /activity and /logs. Fixed and tested both with and without Organizr in use.